### PR TITLE
feat: LCOE constants (#12)

### DIFF
--- a/src/data/lcoe.ts
+++ b/src/data/lcoe.ts
@@ -1,0 +1,9 @@
+export const LCOE: Record<string, { label: string; low: number; high?: number; colour: string }> = {
+  solar:   { label: 'Solar',   low: 60,                colour: '#f0a500' },
+  wind:    { label: 'Wind',    low: 83,                colour: '#3aad63' },
+  gas:     { label: 'Gas',     low: 105,               colour: '#8899aa' },
+  nuclear: { label: 'Nuclear', low: 95,  high: 125,    colour: '#a97fd4' },
+  biomass: { label: 'Biomass', low: 138,               colour: '#5bc9a8' },
+  hydro:   { label: 'Hydro',   low: 0,                 colour: '#2f9960' },
+  imports: { label: 'Imports', low: 0,                 colour: '#6a7fa0' },
+}

--- a/src/utils/intensityBand.ts
+++ b/src/utils/intensityBand.ts
@@ -1,5 +1,8 @@
+const LOW_THRESHOLD = 100
+const MODERATE_THRESHOLD = 200
+
 export function intensityBand(value: number): 'low' | 'moderate' | 'high' {
-  if (value < 100) return 'low'
-  if (value < 200) return 'moderate'
+  if (value < LOW_THRESHOLD) return 'low'
+  if (value < MODERATE_THRESHOLD) return 'moderate'
   return 'high'
 }


### PR DESCRIPTION
## Summary
- Add src/data/lcoe.ts with LCOE record for all fuel types from PRD
- Source: DESNZ Electricity Generation Costs 2025
- Wind = capacity-weighted avg of onshore/offshore/floating

## Acceptance Criteria
- [x] LCOE record exported with all fuel types from PRD
- [x] Typecheck passes
- [x] Lint passes

## Test plan
- [x] pnpm lint — no new errors in src/data/lcoe.ts
- [x] npx tsc --noEmit — clean

Generated with Claude Code
