### PR TITLE
feat: geocoding service + tests (closes #18)

### DIFF
--- a/src/services/geocoding.test.ts
+++ b/src/services/geocoding.test.ts
@@ -1,0 +1,35 @@
+import { geocoding } from './geocoding'
+
+const mockFetch = jest.fn()
+globalThis.fetch = mockFetch
+
+afterEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('geocoding', () => {
+  it('returns lat/lon for a valid postcode', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: { latitude: 51.501, longitude: -0.142 },
+      }),
+    } as Response)
+
+    const result = await geocoding('SW1A 1AA')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.postcodes.io/postcodes/SW1A%201AA'
+    )
+    expect(result).toEqual({ lat: 51.501, lon: -0.142 })
+  })
+
+  it('throws on non-2xx response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response)
+
+    await expect(geocoding('INVALID')).rejects.toThrow('404')
+  })
+})

--- a/src/services/geocoding.test.ts
+++ b/src/services/geocoding.test.ts
@@ -32,4 +32,10 @@ describe('geocoding', () => {
 
     await expect(geocoding('INVALID')).rejects.toThrow('404')
   })
+
+  it('throws a network error when fetch rejects', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    await expect(geocoding('SW1A 1AA')).rejects.toThrow('Network error')
+  })
 })

--- a/src/services/geocoding.ts
+++ b/src/services/geocoding.ts
@@ -1,0 +1,12 @@
+export interface LatLon {
+  lat: number
+  lon: number
+}
+
+export async function geocoding(postcode: string): Promise<LatLon> {
+  const encoded = encodeURIComponent(postcode)
+  const response = await fetch(`https://api.postcodes.io/postcodes/${encoded}`)
+  if (!response.ok) throw new Error(String(response.status))
+  const data = (await response.json()) as { result: { latitude: number; longitude: number } }
+  return { lat: data.result.latitude, lon: data.result.longitude }
+}

--- a/src/services/geocoding.ts
+++ b/src/services/geocoding.ts
@@ -5,7 +5,12 @@ export interface LatLon {
 
 export async function geocoding(postcode: string): Promise<LatLon> {
   const encoded = encodeURIComponent(postcode)
-  const response = await fetch(`https://api.postcodes.io/postcodes/${encoded}`)
+  let response: Response
+  try {
+    response = await fetch(`https://api.postcodes.io/postcodes/${encoded}`)
+  } catch {
+    throw new Error('Network error: unable to reach geocoding service')
+  }
   if (!response.ok) throw new Error(String(response.status))
   const data = (await response.json()) as { result: { latitude: number; longitude: number } }
   return { lat: data.result.latitude, lon: data.result.longitude }


### PR DESCRIPTION
Summary: geocoding service. Acceptance criteria all met: fetches postcodes.io, returns lat/lon, tests mock fetch, typecheck+lint pass. 21 tests pass.