### PR TITLE
feat: fetchJson utility + refactor geocoding

### DIFF
--- a/src/services/geocoding.test.ts
+++ b/src/services/geocoding.test.ts
@@ -19,7 +19,8 @@ describe('geocoding', () => {
     const result = await geocoding('SW1A 1AA')
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.postcodes.io/postcodes/SW1A%201AA'
+      'https://api.postcodes.io/postcodes/SW1A%201AA',
+      undefined,
     )
     expect(result).toEqual({ lat: 51.501, lon: -0.142 })
   })

--- a/src/services/geocoding.ts
+++ b/src/services/geocoding.ts
@@ -1,17 +1,18 @@
+import { fetchJson } from '../utils/fetch-json'
+
 export interface LatLon {
   lat: number
   lon: number
 }
 
+interface PostcodesResponse {
+  result: { latitude: number; longitude: number }
+}
+
 export async function geocoding(postcode: string): Promise<LatLon> {
   const encoded = encodeURIComponent(postcode)
-  let response: Response
-  try {
-    response = await fetch(`https://api.postcodes.io/postcodes/${encoded}`)
-  } catch {
-    throw new Error('Network error: unable to reach geocoding service')
-  }
-  if (!response.ok) throw new Error(String(response.status))
-  const data = (await response.json()) as { result: { latitude: number; longitude: number } }
+  const data = await fetchJson<PostcodesResponse>(
+    `https://api.postcodes.io/postcodes/${encoded}`,
+  )
   return { lat: data.result.latitude, lon: data.result.longitude }
 }

--- a/src/utils/fetch-json.test.ts
+++ b/src/utils/fetch-json.test.ts
@@ -1,0 +1,44 @@
+import { fetchJson } from './fetch-json'
+
+const mockFetch = jest.fn()
+globalThis.fetch = mockFetch
+
+afterEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('fetchJson', () => {
+  it('returns parsed JSON on success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ value: 42 }),
+    } as Response)
+
+    const result = await fetchJson<{ value: number }>('https://example.com')
+    expect(result).toEqual({ value: 42 })
+  })
+
+  it('throws status code string on non-2xx response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('404')
+  })
+
+  it('throws Network error on connectivity failure', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    await expect(fetchJson('https://example.com')).rejects.toThrow('Network error')
+  })
+
+  it('passes options through to fetch', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response)
+
+    const options = { headers: { Authorization: 'Bearer token' } }
+    await fetchJson('https://example.com', options)
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com', options)
+  })
+})

--- a/src/utils/fetch-json.ts
+++ b/src/utils/fetch-json.ts
@@ -1,0 +1,10 @@
+export async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  let response: Response
+  try {
+    response = await fetch(url, options)
+  } catch {
+    throw new Error('Network error')
+  }
+  if (!response.ok) throw new Error(String(response.status))
+  return response.json() as Promise<T>
+}


### PR DESCRIPTION
## Summary
- Add \`src/utils/fetch-json.ts\` — centralises try-catch, non-2xx check, JSON parse
- \`fetchJson<T>(url, options?)\` passes \`RequestInit\` through for auth headers (Octopus)
- Refactor \`geocoding.ts\` to use \`fetchJson\`

## Acceptance Criteria
- [x] Network errors throw \`'Network error'\`
- [x] Non-2xx throws status code string
- [x] \`options\` passed through to fetch
- [x] 4 tests in fetch-json.test.ts
- [x] geocoding.test.ts still passes (3 tests)
- [x] Lint passes

Generated with Claude Code