### PR TITLE
feat(services): octopus 2-step GSP+unit-rate fetch

### DIFF
--- a/src/services/octopus.test.ts
+++ b/src/services/octopus.test.ts
@@ -1,0 +1,74 @@
+import { octopus } from './octopus'
+
+const UNIT_RATE_P = 28.37
+const UNIT_RATE_A = 24.5
+
+const GSP_FIXTURE_P = { results: [{ group_id: '_P' }] }
+const GSP_FIXTURE_A = { results: [{ group_id: '_A' }] }
+const RATE_FIXTURE_P = { results: [{ value_inc_vat: UNIT_RATE_P }] }
+const RATE_FIXTURE_A = { results: [{ value_inc_vat: UNIT_RATE_A }] }
+
+const HTTP_500 = 500
+const HTTP_403 = 403
+
+const mockOkJson = (body: unknown) => ({ ok: true, json: () => Promise.resolve(body) })
+const mockError = (status: number) => ({ ok: false, status })
+
+beforeEach(() => {
+  globalThis.fetch = jest.fn() as typeof fetch
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('octopus — happy path', () => {
+  it('returns unit rate and tariff for postcode (GSP _P)', async () => {
+    ;(globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce(mockOkJson(GSP_FIXTURE_P))
+      .mockResolvedValueOnce(mockOkJson(RATE_FIXTURE_P))
+
+    const result = await octopus('NR1 4AA')
+
+    expect(result.value).toBe(UNIT_RATE_P)
+    expect(result.tariff).toBe('E-1R-VAR-22-11-01-P')
+  })
+
+  it('strips leading underscore to derive GSP letter (GSP _A)', async () => {
+    ;(globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce(mockOkJson(GSP_FIXTURE_A))
+      .mockResolvedValueOnce(mockOkJson(RATE_FIXTURE_A))
+
+    const result = await octopus('SW1A 1AA')
+
+    expect(result.tariff).toBe('E-1R-VAR-22-11-01-A')
+    expect(result.value).toBe(UNIT_RATE_A)
+  })
+
+  it('calls GSP endpoint with URL-encoded postcode', async () => {
+    ;(globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce(mockOkJson(GSP_FIXTURE_P))
+      .mockResolvedValueOnce(mockOkJson(RATE_FIXTURE_P))
+
+    await octopus('NR1 4AA')
+
+    const [firstUrl] = (globalThis.fetch as jest.Mock).mock.calls[0] as [string]
+    expect(firstUrl).toBe(
+      'https://api.octopus.energy/v1/industry/grid-supply-points/?postcode=NR1%204AA',
+    )
+  })
+})
+
+describe('octopus — errors', () => {
+  it('throws on non-2xx GSP response', async () => {
+    ;(globalThis.fetch as jest.Mock).mockResolvedValueOnce(mockError(HTTP_500))
+    await expect(octopus('NR1 4AA')).rejects.toThrow(String(HTTP_500))
+  })
+
+  it('throws on non-2xx unit rate response', async () => {
+    ;(globalThis.fetch as jest.Mock)
+      .mockResolvedValueOnce(mockOkJson(GSP_FIXTURE_P))
+      .mockResolvedValueOnce(mockError(HTTP_403))
+    await expect(octopus('NR1 4AA')).rejects.toThrow(String(HTTP_403))
+  })
+})

--- a/src/services/octopus.ts
+++ b/src/services/octopus.ts
@@ -1,0 +1,31 @@
+import { fetchJson } from '../utils/fetch-json'
+
+export interface OctopusResult {
+  value: number
+  tariff: string
+}
+
+interface GspResponse {
+  results: Array<{ group_id: string }>
+}
+
+interface UnitRateResponse {
+  results: Array<{ value_inc_vat: number }>
+}
+
+const PRODUCT = 'VAR-22-11-01'
+
+export async function octopus(postcode: string): Promise<OctopusResult> {
+  const encoded = encodeURIComponent(postcode)
+  const gspData = await fetchJson<GspResponse>(
+    `https://api.octopus.energy/v1/industry/grid-supply-points/?postcode=${encoded}`,
+  )
+  const gsp = gspData.results[0].group_id.replace(/^_/, '')
+  const tariff = `E-1R-${PRODUCT}-${gsp}`
+
+  const rateData = await fetchJson<UnitRateResponse>(
+    `https://api.octopus.energy/v1/products/${PRODUCT}/electricity-tariffs/${tariff}/standard-unit-rates/?page_size=1`,
+  )
+
+  return { value: rateData.results[0].value_inc_vat, tariff }
+}


### PR DESCRIPTION
Closes #19. octopus.ts: 2-step fetch GSP lookup then standard unit rate. 5 tests: happy path, GSP letter stripping, URL encoding, error states. All 43 tests pass, 0 lint errors.