### PR TITLE
feat(services): air quality service + tests

### DIFF
--- a/src/services/air-quality.test.ts
+++ b/src/services/air-quality.test.ts
@@ -1,0 +1,66 @@
+import { airQuality } from './air-quality'
+import { geocoding } from './geocoding'
+
+jest.mock('./geocoding')
+
+const mockGeocoding = geocoding as jest.MockedFunction<typeof geocoding>
+const mockFetch = jest.fn()
+globalThis.fetch = mockFetch
+
+afterEach(() => {
+  mockFetch.mockReset()
+  mockGeocoding.mockReset()
+})
+
+describe('airQuality', () => {
+  it('calls Open-Meteo with correct lat/lon URL', async () => {
+    mockGeocoding.mockResolvedValueOnce({ lat: 52.628, lon: 1.299 })
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        current: { european_aqi: 10, pm2_5: 1, nitrogen_dioxide: 2, ozone: 3 },
+      }),
+    } as Response)
+
+    await airQuality('NR1 4AA')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://air-quality-api.open-meteo.com/v1/air-quality?latitude=52.628&longitude=1.299&current=european_aqi,pm2_5,nitrogen_dioxide,ozone',
+      undefined,
+    )
+  })
+
+  it('throws on non-2xx from Open-Meteo', async () => {
+    mockGeocoding.mockResolvedValueOnce({ lat: 52.628, lon: 1.299 })
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    } as Response)
+
+    await expect(airQuality('NR1 4AA')).rejects.toThrow('503')
+  })
+
+  it('returns AQI data for valid postcode', async () => {
+    mockGeocoding.mockResolvedValueOnce({ lat: 52.628, lon: 1.299 })
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        current: {
+          european_aqi: 23,
+          pm2_5: 7.1,
+          nitrogen_dioxide: 12.4,
+          ozone: 88,
+        },
+      }),
+    } as Response)
+
+    const result = await airQuality('NR1 4AA')
+
+    expect(result).toEqual({
+      european_aqi: 23,
+      pm2_5: 7.1,
+      nitrogen_dioxide: 12.4,
+      ozone: 88,
+    })
+  })
+})

--- a/src/services/air-quality.ts
+++ b/src/services/air-quality.ts
@@ -1,0 +1,33 @@
+import { fetchJson } from '../utils/fetch-json'
+import { geocoding } from './geocoding'
+
+export interface AirQualityData {
+  european_aqi: number
+  pm2_5: number
+  nitrogen_dioxide: number
+  ozone: number
+}
+
+interface OpenMeteoResponse {
+  current: {
+    european_aqi: number
+    pm2_5: number
+    nitrogen_dioxide: number
+    ozone: number
+  }
+}
+
+export async function airQuality(postcode: string): Promise<AirQualityData> {
+  const { lat, lon } = await geocoding(postcode)
+  const url =
+    `https://air-quality-api.open-meteo.com/v1/air-quality` +
+    `?latitude=${lat}&longitude=${lon}` +
+    `&current=european_aqi,pm2_5,nitrogen_dioxide,ozone`
+  const data = await fetchJson<OpenMeteoResponse>(url)
+  return {
+    european_aqi: data.current.european_aqi,
+    pm2_5: data.current.pm2_5,
+    nitrogen_dioxide: data.current.nitrogen_dioxide,
+    ozone: data.current.ozone,
+  }
+}


### PR DESCRIPTION
Implements airQuality(postcode) using Open-Meteo API via geocoding lat/lon lookup. Closes #20. All 3 acceptance criteria met: correct URL, data extraction, error handling. 41/41 tests pass, 0 lint errors.