### PR TITLE
feat(components): RegionHeader + test (closes #27)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,4 +10,5 @@ module.exports = {
   testPathIgnorePatterns: [
     '/node_modules/',
   ],
+  setupFilesAfterEnv: ['./jest.setup.ts'],
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/src/components/results/RegionHeader.test.tsx
+++ b/src/components/results/RegionHeader.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import { RegionHeader } from './RegionHeader'
+
+describe('RegionHeader', () => {
+  it('renders postcode, region name, and GSP letter joined by middle dots', () => {
+    render(<RegionHeader postcode="NR1 4AA" regionName="East England" gspId="_P" />)
+    expect(screen.getByText('NR1 4AA · East England · GSP Region P')).toBeInTheDocument()
+  })
+
+  it('strips leading underscore from gspId', () => {
+    render(<RegionHeader postcode="SW1A 1AA" regionName="South East" gspId="_J" />)
+    expect(screen.getByText('SW1A 1AA · South East · GSP Region J')).toBeInTheDocument()
+  })
+
+  it('handles gspId without underscore prefix', () => {
+    render(<RegionHeader postcode="M1 1AE" regionName="North West" gspId="A" />)
+    expect(screen.getByText('M1 1AE · North West · GSP Region A')).toBeInTheDocument()
+  })
+})

--- a/src/components/results/RegionHeader.tsx
+++ b/src/components/results/RegionHeader.tsx
@@ -1,0 +1,14 @@
+interface Properties {
+  readonly postcode: string
+  readonly regionName: string
+  readonly gspId: string
+}
+
+export function RegionHeader({ postcode, regionName, gspId }: Properties) {
+  const gspLetter = gspId.startsWith('_') ? gspId.slice(1) : gspId
+  return (
+    <p>
+      {postcode} · {regionName} · GSP Region {gspLetter}
+    </p>
+  )
+}

--- a/src/hooks/use-postcode-data.ts
+++ b/src/hooks/use-postcode-data.ts
@@ -147,7 +147,7 @@ export function usePostcodeData(postcode: string): PostcodeDataState {
 
     dispatch({ type: 'loading' })
 
-    Promise.allSettled([fetchCi(context), fetchOctopus(context), fetchAq(context)]).then(() => {
+    void Promise.allSettled([fetchCi(context), fetchOctopus(context), fetchAq(context)]).then(() => {
       if (!ignore.current) dispatch({ type: 'success' })
     })
 

--- a/src/utils/lcoe-weighted-avg.ts
+++ b/src/utils/lcoe-weighted-avg.ts
@@ -3,7 +3,7 @@ export function lcoeWeightedAvg(
   lcoeMap: Record<string, { low: number; [key: string]: unknown }>,
 ): number {
   const matched = generationMix.filter(
-    ({ fuel }) => lcoeMap[fuel] !== undefined && lcoeMap[fuel].low > 0,
+    ({ fuel }) => Object.hasOwn(lcoeMap, fuel) && lcoeMap[fuel].low > 0,
   )
   const totalPerc = matched.reduce((sum, { perc }) => sum + perc, 0)
   if (totalPerc === 0) return 0

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,6 +6,7 @@
     "verbatimModuleSyntax": false,
     "allowImportingTsExtensions": false,
     "noEmit": false,
-    "types": ["jest", "node"]
-  }
+    "types": ["jest", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "jest.setup.ts"]
 }


### PR DESCRIPTION
## Summary

- `RegionHeader.tsx`: displays `{postcode} · {region name} · GSP Region {letter}` — strips leading `_` from gspId
- 3 RTL component tests (tracer bullet + edge cases)
- `jest.setup.ts` + `setupFilesAfterEnv` wiring so `@testing-library/jest-dom` matchers work
- `@testing-library/jest-dom` added to `tsconfig.test.json` types

**Lint fixes (pre-existing):**
- `void` prefix on floating `Promise.allSettled` in `use-postcode-data.ts`
- `Object.hasOwn` replaces `!== undefined` in `lcoe-weighted-avg.ts` (sonarjs)

## Acceptance Criteria

- [x] Displays: `{postcode} · {region name} · GSP Region {gspId}`
- [x] Component test passes
- [x] Typecheck passes
- [x] Lint passes

## Test plan
- [x] `npx jest --config jest.config.cjs` → 59 tests pass
- [x] `pnpm exec eslint .` → 0 errors

Generated with [Claude Code](https://claude.com/claude-code)
