### PR TITLE
feat(components): CarbonIntensityCard

### DIFF
--- a/src/components/Hero.test.tsx
+++ b/src/components/Hero.test.tsx
@@ -11,16 +11,16 @@ describe('Hero', () => {
     expect(screen.getByRole('textbox', { name: /uk postcode/i })).toBeInTheDocument()
   })
 
-  it('renders Look up button', () => {
+  it('renders submit button', () => {
     render(<Hero onSubmit={jest.fn()} />)
-    expect(screen.getByRole('button', { name: /look up/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /get electricity data/i })).toBeInTheDocument()
   })
 
   it('submit with valid postcode calls onSubmit with formatted postcode', () => {
     const onSubmit = jest.fn()
     render(<Hero onSubmit={onSubmit} />)
     fireEvent.change(screen.getByRole('textbox', { name: /uk postcode/i }), { target: { value: 'nr14aa' } })
-    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+    fireEvent.click(screen.getByRole('button', { name: /get electricity data/i }))
     expect(onSubmit).toHaveBeenCalledWith('NR1 4AA')
   })
 
@@ -28,7 +28,7 @@ describe('Hero', () => {
     const onSubmit = jest.fn()
     render(<Hero onSubmit={onSubmit} />)
     fireEvent.change(screen.getByRole('textbox', { name: /uk postcode/i }), { target: { value: 'ZZZZZ' } })
-    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+    fireEvent.click(screen.getByRole('button', { name: /get electricity data/i }))
     expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByRole('alert')).toHaveTextContent('Please enter a valid UK postcode')
   })
@@ -43,7 +43,7 @@ describe('Hero', () => {
   it('error clears when user types after invalid submit', () => {
     render(<Hero onSubmit={jest.fn()} />)
     fireEvent.change(screen.getByRole('textbox', { name: /uk postcode/i }), { target: { value: 'ZZZZZ' } })
-    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+    fireEvent.click(screen.getByRole('button', { name: /get electricity data/i }))
     expect(screen.getByRole('alert')).toBeInTheDocument()
     fireEvent.change(screen.getByRole('textbox', { name: /uk postcode/i }), { target: { value: 'N' } })
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()

--- a/src/components/results/CarbonIntensityCard.test.tsx
+++ b/src/components/results/CarbonIntensityCard.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import { CarbonIntensityCard } from './CarbonIntensityCard'
+
+const baseIntensity = {
+  actual: 142,
+  band: 'moderate' as const,
+  updatedAt: '2025-01-15T14:30:00Z',
+}
+
+describe('CarbonIntensityCard', () => {
+  it('renders the actual value as the hero number', () => {
+    render(<CarbonIntensityCard intensity={baseIntensity} />)
+    expect(screen.getByLabelText('142 grams CO2 per kilowatt-hour')).toBeInTheDocument()
+  })
+
+  it('renders the correct band badge text and aria-label', () => {
+    render(<CarbonIntensityCard intensity={baseIntensity} />)
+    expect(screen.getByRole('img', { name: 'Intensity level: Moderate' })).toBeInTheDocument()
+    expect(screen.getByText('Moderate')).toBeInTheDocument()
+  })
+
+  it('renders Low badge for low band', () => {
+    render(<CarbonIntensityCard intensity={{ ...baseIntensity, band: 'low', actual: 50 }} />)
+    expect(screen.getByRole('img', { name: 'Intensity level: Low' })).toBeInTheDocument()
+  })
+
+  it('sets scale marker left position as percentage of 300', () => {
+    render(<CarbonIntensityCard intensity={baseIntensity} />)
+    const marker = document.querySelector('.intensity-scale-marker') as HTMLElement
+    // 142/300 * 100 = 47.333...%
+    expect(marker.style.left).toBe('47.333333333333336%')
+  })
+
+  it('clamps marker to 100% when actual exceeds 300', () => {
+    render(<CarbonIntensityCard intensity={{ ...baseIntensity, actual: 500 }} />)
+    const marker = document.querySelector('.intensity-scale-marker') as HTMLElement
+    expect(marker.style.left).toBe('100%')
+  })
+
+  it('scale bar container is aria-hidden', () => {
+    render(<CarbonIntensityCard intensity={baseIntensity} />)
+    const scale = document.querySelector('.intensity-scale')
+    expect(scale).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('renders sr-only text with value and band', () => {
+    render(<CarbonIntensityCard intensity={baseIntensity} />)
+    expect(screen.getByText('Carbon intensity: 142 gCO₂/kWh, moderate level')).toBeInTheDocument()
+  })
+
+  it('renders updated timestamp from ISO string', () => {
+    render(<CarbonIntensityCard intensity={baseIntensity} />)
+    // 2025-01-15T14:30:00Z → "Updated 14:30" in Europe/London (UTC in winter)
+    const timestamp = document.querySelector('.intensity-timestamp')
+    expect(timestamp?.textContent).toMatch(/Updated \d{2}:\d{2}/)
+  })
+})

--- a/src/components/results/CarbonIntensityCard.tsx
+++ b/src/components/results/CarbonIntensityCard.tsx
@@ -1,0 +1,127 @@
+const MAX_INTENSITY = 300
+const PERCENT_SCALE = 100
+
+interface Intensity {
+  actual: number
+  band: 'low' | 'moderate' | 'high'
+  updatedAt: string
+}
+
+interface Properties {
+  readonly intensity: Intensity
+}
+
+function bandLabel(band: Intensity['band']): string {
+  if (band === 'low') return 'Low'
+  if (band === 'moderate') return 'Moderate'
+  return 'High'
+}
+
+const timeFormatter = new Intl.DateTimeFormat('en-GB', {
+  hour: '2-digit',
+  minute: '2-digit',
+  timeZone: 'Europe/London',
+})
+
+interface BadgeProperties {
+  readonly band: Intensity['band']
+  readonly colorToken: string
+}
+
+function IntensityBadge({ band, colorToken }: BadgeProperties) {
+  const label = bandLabel(band)
+  return (
+    <div
+      role="img"
+      aria-label={`Intensity level: ${label}`}
+      className="inline-flex items-center gap-[5px] px-3 py-1 rounded-[var(--radius-pill)] text-white text-[var(--text-xs)] font-bold uppercase tracking-[0.06em]"
+      style={{ background: colorToken }}
+    >
+      <span className="w-[5px] h-[5px] rounded-full bg-white/70" aria-hidden="true" />
+      {label}
+    </div>
+  )
+}
+
+interface ScaleBarProperties {
+  readonly actual: number
+  readonly colorToken: string
+}
+
+function ScaleBar({ actual, colorToken }: ScaleBarProperties) {
+  const markerPct = Math.min(PERCENT_SCALE, Math.max(0, (actual / MAX_INTENSITY) * PERCENT_SCALE))
+  return (
+    <div className="intensity-scale mt-[var(--space-md)]" aria-hidden="true">
+      <div
+        className="intensity-scale-bar relative h-[6px] rounded-[3px] opacity-50 overflow-visible"
+        style={{
+          background:
+            'linear-gradient(to right, var(--color-intensity-low) 0%, var(--color-intensity-moderate) 50%, var(--color-intensity-high) 100%)',
+        }}
+        role="presentation"
+      >
+        <div
+          className="intensity-scale-marker absolute top-1/2 w-[14px] h-[14px] rounded-full border-[2.5px] border-[var(--color-surface)]"
+          style={{
+            left: `${markerPct}%`,
+            transform: 'translate(-50%, -50%)',
+            background: colorToken,
+            boxShadow: `0 0 0 2px ${colorToken}, 0 2px 8px rgba(0,0,0,0.4)`,
+          }}
+        />
+      </div>
+      <div className="flex justify-between mt-[var(--space-xs)]">
+        <span className="text-[var(--text-xs)] text-[var(--color-text-disabled)] font-medium">Low · 0</span>
+        <span className="text-[var(--text-xs)] text-[var(--color-text-disabled)] font-medium">200</span>
+        <span className="text-[var(--text-xs)] text-[var(--color-text-disabled)] font-medium">High · 300+</span>
+      </div>
+    </div>
+  )
+}
+
+export function CarbonIntensityCard({ intensity }: Properties) {
+  const colorToken = `var(--color-intensity-${intensity.band})`
+  const bgToken = `var(--color-intensity-${intensity.band}-bg)`
+  const borderToken = `var(--color-intensity-${intensity.band}-border)`
+  const time = timeFormatter.format(new Date(intensity.updatedAt))
+
+  return (
+    <article
+      aria-labelledby="intensity-heading"
+      className="relative overflow-hidden rounded-[var(--radius-card)] p-[var(--space-lg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_4px_32px_rgba(0,0,0,0.45)]"
+      style={{ background: bgToken, border: `1px solid ${borderToken}` }}
+    >
+      <div className="flex items-center justify-between mb-[var(--space-md)]">
+        <span
+          id="intensity-heading"
+          className="text-[var(--text-sm)] font-semibold text-[var(--color-text-secondary)] uppercase tracking-[0.08em]"
+        >
+          Carbon Intensity
+        </span>
+        <IntensityBadge band={intensity.band} colorToken={colorToken} />
+      </div>
+      <div className="flex items-baseline gap-[var(--space-sm)] mb-[var(--space-sm)]">
+        <span
+          className="font-[var(--font-display)] text-[var(--text-hero)] font-extrabold leading-none tabular-nums tracking-[-0.04em]"
+          aria-label={`${intensity.actual} grams CO2 per kilowatt-hour`}
+          style={{ color: colorToken }}
+        >
+          {intensity.actual}
+        </span>
+        <span className="text-base font-normal text-[var(--color-text-secondary)] pb-[6px]" aria-hidden="true">
+          gCO₂/kWh
+        </span>
+      </div>
+      <ScaleBar actual={intensity.actual} colorToken={colorToken} />
+      <span className="sr-only">
+        Carbon intensity: {intensity.actual} gCO₂/kWh, {intensity.band} level
+      </span>
+      <p
+        className="intensity-timestamp mt-[var(--space-md)] text-[var(--text-xs)] text-[var(--color-text-disabled)]"
+        aria-label={`Data updated at ${time}`}
+      >
+        Updated {time}
+      </p>
+    </article>
+  )
+}


### PR DESCRIPTION
Closes 28. CarbonIntensityCard with hero number, band badge, gradient scale bar, marker, timestamp, sr-only text. Band colours via CSS tokens. Scale marker clamped 0-100 across 0-300 scale. All 8 component tests pass, 82/82 suite green, 0 lint errors. Also fixes pre-existing Hero test regression (button accessible name mismatch). Acceptance: hero number correct, badge text/colour correct, scale bar aria-hidden, marker at right pct, sr-only summary present, typecheck and lint pass.