### PR TITLE
feat(#29): GenerationMixCard — donut SVG, legend, LCOE column

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -44,7 +44,7 @@ function PostcodeForm({ onSubmit }: Readonly<HeroProperties>) {
           autoComplete="postal-code"
           spellCheck={false}
         />
-        <Primitive.button type="submit" className="flex-shrink-0 bg-[#3aad63] text-white rounded-[var(--radius-button)] text-sm font-semibold px-4 py-2 hover:bg-[#52c278] flex items-center gap-1 whitespace-nowrap cursor-pointer" aria-label="Get electricity data for postcode">
+        <Primitive.button type="submit" className="flex-shrink-0 bg-[#3aad63] text-white rounded-[var(--radius-button)] text-sm font-semibold px-4 py-2 hover:bg-[#52c278] flex items-center gap-1 whitespace-nowrap cursor-pointer" aria-label="Look up postcode">
           {ARROW_ICON}
           Look up
         </Primitive.button>

--- a/src/components/results/GenerationMixCard.test.tsx
+++ b/src/components/results/GenerationMixCard.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import { LCOE } from '../../data/lcoe'
+import { GenerationMixCard } from './GenerationMixCard'
+
+const sampleMix = [
+  { fuel: 'wind', perc: 32 },
+  { fuel: 'gas', perc: 28 },
+  { fuel: 'nuclear', perc: 18 },
+  { fuel: 'solar', perc: 8 },
+  { fuel: 'biomass', perc: 7 },
+  { fuel: 'imports', perc: 5 },
+  { fuel: 'hydro', perc: 2 },
+]
+
+describe('GenerationMixCard', () => {
+  it('renders all fuels in the legend', () => {
+    render(<GenerationMixCard mix={sampleMix} lcoe={LCOE} />)
+    const legend = screen.getByRole('list', { name: /generation mix legend/i })
+    expect(legend).toHaveTextContent('Wind')
+    expect(legend).toHaveTextContent('Gas')
+    expect(legend).toHaveTextContent('Nuclear')
+    expect(legend).toHaveTextContent('Solar')
+    expect(legend).toHaveTextContent('Biomass')
+    expect(legend).toHaveTextContent('Imports')
+    expect(legend).toHaveTextContent('Hydro')
+  })
+
+  it('shows LCOE value for fuels with known cost; dash for zero-cost fuels', () => {
+    render(<GenerationMixCard mix={sampleMix} lcoe={LCOE} />)
+    expect(screen.getByText('£83/MWh')).toBeInTheDocument()  // wind
+    expect(screen.getByText('£105/MWh')).toBeInTheDocument() // gas
+    expect(screen.getByText('£60/MWh')).toBeInTheDocument()  // solar
+    // hydro and imports have low=0 → show dash
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('centre label shows dominant fuel name and percentage', () => {
+    render(<GenerationMixCard mix={sampleMix} lcoe={LCOE} />)
+    // Wind is dominant at 32% — centre label is aria-hidden but still in DOM
+    // The donut wrapper div is also aria-hidden; check the one with text content
+    const allHidden = document.querySelectorAll('[aria-hidden="true"]')
+    const centreDiv = [...allHidden].find(element => element.textContent?.includes('32%') && element.textContent?.includes('Wind'))
+    expect(centreDiv).toBeTruthy()
+  })
+
+  it('donut wrapper has role="img" with aria-label listing each fuel and percentage', () => {
+    render(<GenerationMixCard mix={sampleMix} lcoe={LCOE} />)
+    const donut = screen.getByRole('img', { name: /Generation mix donut chart/i })
+    expect(donut).toBeInTheDocument()
+    expect(donut).toHaveAttribute('aria-label', expect.stringContaining('Wind 32%'))
+    expect(donut).toHaveAttribute('aria-label', expect.stringContaining('Gas 28%'))
+  })
+
+  it('shows LCOE range for nuclear (£95-125/MWh)', () => {
+    render(<GenerationMixCard mix={sampleMix} lcoe={LCOE} />)
+    expect(screen.getByText('£95-125/MWh')).toBeInTheDocument()
+  })
+})

--- a/src/components/results/GenerationMixCard.tsx
+++ b/src/components/results/GenerationMixCard.tsx
@@ -1,0 +1,111 @@
+import type { CSSProperties } from 'react'
+
+const DONUT_RADIUS = 56
+const CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS
+const GAP = 3
+const PERCENT = 100
+
+interface FuelEntry { readonly fuel: string; readonly perc: number }
+interface LcoeEntry { readonly label: string; readonly low: number; readonly high?: number; readonly colour: string }
+interface Properties { readonly mix: FuelEntry[]; readonly lcoe: Record<string, LcoeEntry> }
+interface Segment { fuel: string; colour: string; dashArray: string; dashOffset: number }
+
+function fuelLabel(fuel: string, entry: LcoeEntry | undefined): string {
+  return entry?.label ?? fuel.charAt(0).toUpperCase() + fuel.slice(1)
+}
+
+function buildDonutAriaLabel(sorted: FuelEntry[], lcoe: Record<string, LcoeEntry>): string {
+  const parts = sorted.map(({ fuel, perc }) => `${fuelLabel(fuel, lcoe[fuel])} ${perc}%`)
+  return `Generation mix donut chart: ${parts.join(', ')}`
+}
+
+function buildSegments(sorted: FuelEntry[], lcoe: Record<string, LcoeEntry>): Segment[] {
+  let cumulative = 0
+  return sorted.map(({ fuel, perc }) => {
+    const colour = lcoe[fuel]?.colour ?? '#888'
+    const segLength = (perc / PERCENT) * CIRCUMFERENCE - GAP
+    const dashOffset = -cumulative
+    cumulative += (perc / PERCENT) * CIRCUMFERENCE
+    return { fuel, colour, dashArray: `${segLength.toFixed(2)} ${CIRCUMFERENCE.toFixed(2)}`, dashOffset }
+  })
+}
+
+function formatLcoe(entry: LcoeEntry | undefined): string {
+  if (!entry || entry.low === 0) return '—'
+  if (entry.high) return `£${entry.low}-${entry.high}/MWh`
+  return `£${entry.low}/MWh`
+}
+
+const CARD_STYLE: CSSProperties = { background: 'var(--color-surface)', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-card)', padding: 'var(--space-lg)', boxShadow: '0 2px 24px rgba(0,0,0,0.32)' }
+const HEADING_STYLE: CSSProperties = { fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--color-text-primary)', marginBottom: 'var(--space-lg)', display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }
+const LEGEND_STYLE: CSSProperties = { flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }
+const FOOTER_STYLE: CSSProperties = { fontSize: 'var(--text-xs)', color: 'var(--color-text-disabled)', marginTop: 'var(--space-md)' }
+
+interface CentreProperties { readonly dominant: FuelEntry | undefined; readonly label: string }
+
+function DonutCentreLabel({ dominant, label }: Readonly<CentreProperties>) {
+  return (
+    <div aria-hidden="true" style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center' }}>
+      <span style={{ fontSize: 'var(--text-xs)', fontWeight: 600, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{label}</span>
+      <span style={{ fontFamily: 'var(--font-display)', fontSize: '1.75rem', fontWeight: 800, color: 'var(--color-text-primary)', fontVariantNumeric: 'tabular-nums' }}>{dominant?.perc}%</span>
+    </div>
+  )
+}
+
+interface DonutProperties { readonly sorted: FuelEntry[]; readonly lcoe: Record<string, LcoeEntry> }
+
+function DonutChart({ sorted, lcoe }: DonutProperties) {
+  const dominant = sorted[0]
+  const segments = buildSegments(sorted, lcoe)
+  const ariaLabel = buildDonutAriaLabel(sorted, lcoe)
+  const dominantLabel = dominant ? fuelLabel(dominant.fuel, lcoe[dominant.fuel]) : ''
+  return (
+    <div role="img" aria-label={ariaLabel} style={{ flexShrink: 0, position: 'relative', width: 160, height: 160 }}>
+      <svg viewBox="0 0 160 160" width="160" height="160" aria-hidden="true" style={{ transform: 'rotate(-90deg)' }}>
+        {segments.map(({ fuel, colour, dashArray, dashOffset }) => (
+          <circle key={fuel} cx="80" cy="80" r={DONUT_RADIUS} fill="none" stroke={colour} strokeWidth="22" strokeDasharray={dashArray} strokeDashoffset={dashOffset} />
+        ))}
+      </svg>
+      <DonutCentreLabel dominant={dominant} label={dominantLabel} />
+    </div>
+  )
+}
+
+interface LegendItemProperties { readonly fuel: string; readonly perc: number; readonly entry: LcoeEntry | undefined }
+
+function LegendItem({ fuel, perc, entry }: LegendItemProperties) {
+  const label = fuelLabel(fuel, entry)
+  const colour = entry?.colour ?? '#888'
+  return (
+    <li role="listitem" style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
+      <span aria-hidden="true" style={{ width: 9, height: 9, borderRadius: '50%', background: colour, flexShrink: 0 }} />
+      <span className="legend-fuel" style={{ flex: 1, fontSize: 'var(--text-sm)', fontWeight: 500, color: 'var(--color-text-secondary)' }}>{label}</span>
+      <span style={{ fontSize: 'var(--text-sm)', fontWeight: 700, color: 'var(--color-text-primary)', fontVariantNumeric: 'tabular-nums' }}>{perc}%</span>
+      <span className="legend-lcoe" style={{ fontSize: 10, fontWeight: 500, color: 'var(--color-text-disabled)', fontVariantNumeric: 'tabular-nums', minWidth: 96, textAlign: 'right' }}>{formatLcoe(entry)}</span>
+    </li>
+  )
+}
+
+const MIX_ICON = (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <circle cx="9" cy="9" r="8" stroke="#3aad63" strokeWidth="1.5" />
+    <path d="M9 9 L9 3.5 A5.5 5.5 0 0 1 13.76 12 Z" fill="#3aad63" opacity="0.8" />
+    <path d="M9 9 L13.76 12 A5.5 5.5 0 0 1 4.6 13.7 Z" fill="#8899aa" opacity="0.8" />
+  </svg>
+)
+
+export function GenerationMixCard({ mix, lcoe }: Properties) {
+  const sorted = mix.toSorted((a, b) => b.perc - a.perc)
+  return (
+    <article style={CARD_STYLE}>
+      <h2 style={HEADING_STYLE}>{MIX_ICON}Generation Mix</h2>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
+        <DonutChart sorted={sorted} lcoe={lcoe} />
+        <ul role="list" aria-label="Generation mix legend" style={LEGEND_STYLE}>
+          {sorted.map(({ fuel, perc }) => <LegendItem key={fuel} fuel={fuel} perc={perc} entry={lcoe[fuel]} />)}
+        </ul>
+      </div>
+      <p style={FOOTER_STYLE}>LCOE figures from DESNZ Electricity Generation Costs 2025 (January 2026), 2030 commissioning estimates. — indicates no published figure for this edition.</p>
+    </article>
+  )
+}


### PR DESCRIPTION
Summary: donut SVG chart with role=img; legend sorted by percent; LCOE column with dash for zero-cost fuels. Also fixed Hero.tsx button aria-label (was breaking 4 tests). All 79 tests pass, 0 lint errors.