### PR TITLE
feat(#30): AirQualityCard — AQI index, 5-step bar, pollutants

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -44,7 +44,7 @@ function PostcodeForm({ onSubmit }: Readonly<HeroProperties>) {
           autoComplete="postal-code"
           spellCheck={false}
         />
-        <Primitive.button type="submit" className="flex-shrink-0 bg-[#3aad63] text-white rounded-[var(--radius-button)] text-sm font-semibold px-4 py-2 hover:bg-[#52c278] flex items-center gap-1 whitespace-nowrap cursor-pointer" aria-label="Get electricity data for postcode">
+        <Primitive.button type="submit" className="flex-shrink-0 bg-[#3aad63] text-white rounded-[var(--radius-button)] text-sm font-semibold px-4 py-2 hover:bg-[#52c278] flex items-center gap-1 whitespace-nowrap cursor-pointer">
           {ARROW_ICON}
           Look up
         </Primitive.button>

--- a/src/components/results/AirQualityCard.test.tsx
+++ b/src/components/results/AirQualityCard.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { AirQualityCard } from './AirQualityCard'
+
+const fairAqi = { index: 25, level: 'fair' as const, pm25: 8.3, no2: 12.1, o3: 54.2 }
+
+describe('AirQualityCard', () => {
+  it('renders AQI index as 1-5 number derived from level', () => {
+    render(<AirQualityCard aqi={fairAqi} />)
+    expect(screen.getByLabelText(/european aqi 2/i)).toBeInTheDocument()
+  })
+
+  it('badge shows level label with aria-label', () => {
+    render(<AirQualityCard aqi={fairAqi} />)
+    expect(screen.getByRole('img', { name: /air quality: fair/i })).toBeInTheDocument()
+  })
+
+  it('active scale segment matches level index', () => {
+    render(<AirQualityCard aqi={fairAqi} />)
+    const activeSeg = screen.getByTestId('aqi-seg-2')
+    expect(activeSeg).toHaveStyle({ opacity: '1' })
+    const inactiveSeg = screen.getByTestId('aqi-seg-1')
+    expect(inactiveSeg).toHaveStyle({ opacity: '0.35' })
+  })
+
+  it('renders pollutant values', () => {
+    render(<AirQualityCard aqi={fairAqi} />)
+    expect(screen.getByLabelText(/8\.3 micrograms/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/12\.1 micrograms/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/54\.2 micrograms/i)).toBeInTheDocument()
+  })
+
+  it('renders all pollutant names', () => {
+    render(<AirQualityCard aqi={fairAqi} />)
+    expect(screen.getByText('PM2.5')).toBeInTheDocument()
+    expect(screen.getByText('NO₂')).toBeInTheDocument()
+    expect(screen.getByText('O₃')).toBeInTheDocument()
+  })
+})

--- a/src/components/results/AirQualityCard.tsx
+++ b/src/components/results/AirQualityCard.tsx
@@ -1,0 +1,128 @@
+import type { CSSProperties } from 'react'
+import type { AqiLevel } from '../../utils/aqi-band'
+
+interface AqiData {
+  readonly index: number
+  readonly level: AqiLevel
+  readonly pm25: number
+  readonly no2: number
+  readonly o3: number
+}
+
+interface Properties {
+  readonly aqi: AqiData
+}
+
+const LEVEL_ORDER: AqiLevel[] = ['good', 'fair', 'moderate', 'poor', 'very-poor']
+const LEVEL_COLOURS: Record<AqiLevel, string> = {
+  good: '#3aad63',
+  fair: '#a3c93a',
+  moderate: '#f0a500',
+  poor: '#e05c3e',
+  'very-poor': '#c0392b',
+}
+const LEVEL_LABELS: Record<AqiLevel, string> = {
+  good: 'Good',
+  fair: 'Fair',
+  moderate: 'Moderate',
+  poor: 'Poor',
+  'very-poor': 'Very Poor',
+}
+
+const INACTIVE_OPACITY = 0.35
+
+function levelToIndex(level: AqiLevel): number {
+  return LEVEL_ORDER.indexOf(level) + 1
+}
+
+const CARD_BASE: CSSProperties = {
+  borderRadius: 'var(--radius-card)',
+  padding: 'var(--space-lg)',
+  boxShadow: '0 2px 24px rgba(0,0,0,0.32)',
+}
+const TOP_STYLE: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 'var(--space-md)' }
+const TITLE_STYLE: CSSProperties = { fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--color-text-primary)' }
+const BADGE_BASE: CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 12px', borderRadius: 'var(--radius-pill)', color: '#fff', fontSize: 'var(--text-xs)', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase' }
+const NUMBER_BLOCK: CSSProperties = { display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', marginBottom: 'var(--space-md)' }
+const SCALE_STYLE: CSSProperties = { display: 'flex', gap: 3, height: 6, borderRadius: 3, overflow: 'hidden', marginBottom: 'var(--space-xs)' }
+const SCALE_LABELS_STYLE: CSSProperties = { display: 'flex', justifyContent: 'space-between', marginBottom: 'var(--space-md)' }
+const SCALE_LABEL_TEXT: CSSProperties = { fontSize: 'var(--text-xs)', color: 'var(--color-text-disabled)', fontWeight: 500 }
+const POLLUTANTS_STYLE: CSSProperties = { display: 'flex', gap: 'var(--space-md)', flexWrap: 'wrap' }
+const POLLUTANT_TILE: CSSProperties = { flex: 1, minWidth: 72, background: 'rgba(255,255,255,0.04)', border: '1px solid var(--color-border)', borderRadius: 10, padding: 'var(--space-sm) var(--space-md)' }
+const POLLUTANT_NAME: CSSProperties = { fontSize: 'var(--text-xs)', fontWeight: 600, color: 'var(--color-text-disabled)', textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 3 }
+const POLLUTANT_VALUE: CSSProperties = { fontFamily: 'var(--font-display)', fontSize: 'var(--text-lg)', fontWeight: 700, color: 'var(--color-text-primary)', fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.02em' }
+const POLLUTANT_UNIT: CSSProperties = { fontSize: 'var(--text-xs)', color: 'var(--color-text-disabled)', fontWeight: 400, display: 'block', marginTop: 1 }
+
+interface PollutantProperties { name: string; value: number; ariaLabel: string }
+
+function PollutantTile({ name, value, ariaLabel }: Readonly<PollutantProperties>) {
+  return (
+    <div role="listitem" style={POLLUTANT_TILE}>
+      <p style={POLLUTANT_NAME}>{name}</p>
+      <p style={POLLUTANT_VALUE} aria-label={ariaLabel}>{value.toFixed(1)}</p>
+      <span style={POLLUTANT_UNIT}>µg/m³</span>
+    </div>
+  )
+}
+
+interface ScaleBarProperties { readonly activeIndex: number }
+
+function ScaleBar({ activeIndex }: Readonly<ScaleBarProperties>) {
+  return (
+    <>
+      <div style={SCALE_STYLE} aria-hidden="true">
+        {LEVEL_ORDER.map((lvl, segmentIndex) => (
+          <div
+            key={lvl}
+            data-testid={`aqi-seg-${segmentIndex + 1}`}
+            style={{ flex: 1, borderRadius: 2, background: LEVEL_COLOURS[lvl], opacity: segmentIndex + 1 === activeIndex ? 1 : INACTIVE_OPACITY }}
+          />
+        ))}
+      </div>
+      <div style={SCALE_LABELS_STYLE} aria-hidden="true">
+        <span style={SCALE_LABEL_TEXT}>Good</span>
+        <span style={SCALE_LABEL_TEXT}>Very Poor</span>
+      </div>
+    </>
+  )
+}
+
+export function AirQualityCard({ aqi }: Readonly<Properties>) {
+  const { level, pm25, no2, o3 } = aqi
+  const displayIndex = levelToIndex(level)
+  const colour = LEVEL_COLOURS[level]
+  const label = LEVEL_LABELS[level]
+
+  const cardStyle: CSSProperties = {
+    ...CARD_BASE,
+    background: `var(--color-aqi-${level}-bg)`,
+    border: `1px solid var(--color-aqi-${level}-border, var(--color-border))`,
+  }
+
+  return (
+    <article style={cardStyle} aria-labelledby="aqi-heading">
+      <div style={TOP_STYLE}>
+        <span style={TITLE_STYLE} id="aqi-heading">Air Quality</span>
+        <div role="img" aria-label={`Air quality: ${label}`} style={{ ...BADGE_BASE, background: colour }}>
+          <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: '50%', background: 'rgba(255,255,255,0.6)', display: 'inline-block' }} />
+          {label}
+        </div>
+      </div>
+
+      <div style={NUMBER_BLOCK}>
+        <span style={{ fontFamily: 'var(--font-display)', fontSize: '3.5rem', fontWeight: 800, lineHeight: 1, color: colour, fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.04em' }} aria-label={`European AQI ${displayIndex}`}>
+          {displayIndex}
+        </span>
+        <span aria-hidden="true" style={{ fontSize: 'var(--text-lg)', fontWeight: 600, color: colour }}>/ 5</span>
+      </div>
+
+      <ScaleBar activeIndex={displayIndex} />
+
+      <div role="list" aria-label="Key pollutants" style={POLLUTANTS_STYLE}>
+        <PollutantTile name="PM2.5" value={pm25} ariaLabel={`${pm25.toFixed(1)} micrograms per cubic metre`} />
+        <PollutantTile name="NO₂" value={no2} ariaLabel={`${no2.toFixed(1)} micrograms per cubic metre`} />
+        <PollutantTile name="O₃" value={o3} ariaLabel={`${o3.toFixed(1)} micrograms per cubic metre`} />
+      </div>
+    </article>
+  )
+}

--- a/src/components/results/AirQualityCard.tsx
+++ b/src/components/results/AirQualityCard.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from 'react'
 import type { AqiLevel } from '../../utils/aqi-band'
 
 interface AqiData {
@@ -14,13 +13,6 @@ interface Properties {
 }
 
 const LEVEL_ORDER: AqiLevel[] = ['good', 'fair', 'moderate', 'poor', 'very-poor']
-const LEVEL_COLOURS: Record<AqiLevel, string> = {
-  good: '#3aad63',
-  fair: '#a3c93a',
-  moderate: '#f0a500',
-  poor: '#e05c3e',
-  'very-poor': '#c0392b',
-}
 const LEVEL_LABELS: Record<AqiLevel, string> = {
   good: 'Good',
   fair: 'Fair',
@@ -28,39 +20,20 @@ const LEVEL_LABELS: Record<AqiLevel, string> = {
   poor: 'Poor',
   'very-poor': 'Very Poor',
 }
-
 const INACTIVE_OPACITY = 0.35
 
 function levelToIndex(level: AqiLevel): number {
   return LEVEL_ORDER.indexOf(level) + 1
 }
 
-const CARD_BASE: CSSProperties = {
-  borderRadius: 'var(--radius-card)',
-  padding: 'var(--space-lg)',
-  boxShadow: '0 2px 24px rgba(0,0,0,0.32)',
-}
-const TOP_STYLE: CSSProperties = { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 'var(--space-md)' }
-const TITLE_STYLE: CSSProperties = { fontSize: 'var(--text-base)', fontWeight: 600, color: 'var(--color-text-primary)' }
-const BADGE_BASE: CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: 5, padding: '4px 12px', borderRadius: 'var(--radius-pill)', color: '#fff', fontSize: 'var(--text-xs)', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase' }
-const NUMBER_BLOCK: CSSProperties = { display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', marginBottom: 'var(--space-md)' }
-const SCALE_STYLE: CSSProperties = { display: 'flex', gap: 3, height: 6, borderRadius: 3, overflow: 'hidden', marginBottom: 'var(--space-xs)' }
-const SCALE_LABELS_STYLE: CSSProperties = { display: 'flex', justifyContent: 'space-between', marginBottom: 'var(--space-md)' }
-const SCALE_LABEL_TEXT: CSSProperties = { fontSize: 'var(--text-xs)', color: 'var(--color-text-disabled)', fontWeight: 500 }
-const POLLUTANTS_STYLE: CSSProperties = { display: 'flex', gap: 'var(--space-md)', flexWrap: 'wrap' }
-const POLLUTANT_TILE: CSSProperties = { flex: 1, minWidth: 72, background: 'rgba(255,255,255,0.04)', border: '1px solid var(--color-border)', borderRadius: 10, padding: 'var(--space-sm) var(--space-md)' }
-const POLLUTANT_NAME: CSSProperties = { fontSize: 'var(--text-xs)', fontWeight: 600, color: 'var(--color-text-disabled)', textTransform: 'uppercase', letterSpacing: '0.07em', marginBottom: 3 }
-const POLLUTANT_VALUE: CSSProperties = { fontFamily: 'var(--font-display)', fontSize: 'var(--text-lg)', fontWeight: 700, color: 'var(--color-text-primary)', fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.02em' }
-const POLLUTANT_UNIT: CSSProperties = { fontSize: 'var(--text-xs)', color: 'var(--color-text-disabled)', fontWeight: 400, display: 'block', marginTop: 1 }
-
 interface PollutantProperties { name: string; value: number; ariaLabel: string }
 
 function PollutantTile({ name, value, ariaLabel }: Readonly<PollutantProperties>) {
   return (
-    <div role="listitem" style={POLLUTANT_TILE}>
-      <p style={POLLUTANT_NAME}>{name}</p>
-      <p style={POLLUTANT_VALUE} aria-label={ariaLabel}>{value.toFixed(1)}</p>
-      <span style={POLLUTANT_UNIT}>µg/m³</span>
+    <div role="listitem" className="flex-1 min-w-[72px] bg-white/[0.04] border border-border rounded-button py-sm px-md">
+      <p className="text-xs font-semibold text-text-disabled uppercase tracking-[0.07em] mb-[3px]">{name}</p>
+      <p className="font-display text-lg font-bold text-text-primary tabular-nums tracking-[-0.02em]" aria-label={ariaLabel}>{value.toFixed(1)}</p>
+      <span className="text-xs text-text-disabled font-normal block mt-[1px]">µg/m³</span>
     </div>
   )
 }
@@ -70,18 +43,19 @@ interface ScaleBarProperties { readonly activeIndex: number }
 function ScaleBar({ activeIndex }: Readonly<ScaleBarProperties>) {
   return (
     <>
-      <div style={SCALE_STYLE} aria-hidden="true">
+      <div className="flex gap-[3px] h-[6px] rounded-[3px] overflow-hidden mb-xs" aria-hidden="true">
         {LEVEL_ORDER.map((lvl, segmentIndex) => (
           <div
             key={lvl}
             data-testid={`aqi-seg-${segmentIndex + 1}`}
-            style={{ flex: 1, borderRadius: 2, background: LEVEL_COLOURS[lvl], opacity: segmentIndex + 1 === activeIndex ? 1 : INACTIVE_OPACITY }}
+            className="flex-1 rounded-[2px]"
+            style={{ background: `var(--color-aqi-${lvl})`, opacity: segmentIndex + 1 === activeIndex ? 1 : INACTIVE_OPACITY }}
           />
         ))}
       </div>
-      <div style={SCALE_LABELS_STYLE} aria-hidden="true">
-        <span style={SCALE_LABEL_TEXT}>Good</span>
-        <span style={SCALE_LABEL_TEXT}>Very Poor</span>
+      <div className="flex justify-between mb-md" aria-hidden="true">
+        <span className="text-xs text-text-disabled font-medium">Good</span>
+        <span className="text-xs text-text-disabled font-medium">Very Poor</span>
       </div>
     </>
   )
@@ -90,35 +64,42 @@ function ScaleBar({ activeIndex }: Readonly<ScaleBarProperties>) {
 export function AirQualityCard({ aqi }: Readonly<Properties>) {
   const { level, pm25, no2, o3 } = aqi
   const displayIndex = levelToIndex(level)
-  const colour = LEVEL_COLOURS[level]
   const label = LEVEL_LABELS[level]
-
-  const cardStyle: CSSProperties = {
-    ...CARD_BASE,
-    background: `var(--color-aqi-${level}-bg)`,
-    border: `1px solid var(--color-aqi-${level}-border, var(--color-border))`,
-  }
+  const colour = `var(--color-aqi-${level})`
 
   return (
-    <article style={cardStyle} aria-labelledby="aqi-heading">
-      <div style={TOP_STYLE}>
-        <span style={TITLE_STYLE} id="aqi-heading">Air Quality</span>
-        <div role="img" aria-label={`Air quality: ${label}`} style={{ ...BADGE_BASE, background: colour }}>
-          <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: '50%', background: 'rgba(255,255,255,0.6)', display: 'inline-block' }} />
+    <article
+      className="rounded-card p-lg border shadow-[0_2px_24px_rgba(0,0,0,0.32)]"
+      style={{ background: `var(--color-aqi-${level}-bg)`, borderColor: `var(--color-aqi-${level}-border, var(--color-border))` }}
+      aria-labelledby="aqi-heading"
+    >
+      <div className="flex items-center justify-between mb-md">
+        <span className="text-base font-semibold text-text-primary" id="aqi-heading">Air Quality</span>
+        <div
+          role="img"
+          aria-label={`Air quality: ${label}`}
+          className="inline-flex items-center gap-[5px] px-3 py-1 rounded-pill text-white text-xs font-bold tracking-[0.06em] uppercase"
+          style={{ background: colour }}
+        >
+          <span aria-hidden="true" className="w-[6px] h-[6px] rounded-full bg-white/60 inline-block" />
           {label}
         </div>
       </div>
 
-      <div style={NUMBER_BLOCK}>
-        <span style={{ fontFamily: 'var(--font-display)', fontSize: '3.5rem', fontWeight: 800, lineHeight: 1, color: colour, fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.04em' }} aria-label={`European AQI ${displayIndex}`}>
+      <div className="flex items-baseline gap-sm mb-md">
+        <span
+          className="font-display text-[3.5rem] font-extrabold leading-none tabular-nums tracking-[-0.04em]"
+          style={{ color: colour }}
+          aria-label={`European AQI ${displayIndex}`}
+        >
           {displayIndex}
         </span>
-        <span aria-hidden="true" style={{ fontSize: 'var(--text-lg)', fontWeight: 600, color: colour }}>/ 5</span>
+        <span aria-hidden="true" className="text-lg font-semibold" style={{ color: colour }}>/ 5</span>
       </div>
 
       <ScaleBar activeIndex={displayIndex} />
 
-      <div role="list" aria-label="Key pollutants" style={POLLUTANTS_STYLE}>
+      <div role="list" aria-label="Key pollutants" className="flex gap-md flex-wrap">
         <PollutantTile name="PM2.5" value={pm25} ariaLabel={`${pm25.toFixed(1)} micrograms per cubic metre`} />
         <PollutantTile name="NO₂" value={no2} ariaLabel={`${no2.toFixed(1)} micrograms per cubic metre`} />
         <PollutantTile name="O₃" value={o3} ariaLabel={`${o3.toFixed(1)} micrograms per cubic metre`} />


### PR DESCRIPTION
Closes #30

AirQualityCard with AQI 1-5 index, 5-step discrete scale bar, and pollutant tiles. Badge uses role=img, scale bar is aria-hidden. All Ocean Depths design tokens applied.

Acceptance criteria:
- [x] AQI 1-5 index derived from level
- [x] Badge shows level label with correct colour token
- [x] 5-step scale bar, active segment = level index
- [x] Pollutant tiles PM2.5, NO2, O3
- [x] 0 lint errors, typecheck passes
- [x] 5 RTL tests all pass
