### PR TITLE
feat(#33): App.tsx landing/results view-state, 2-column desktop grid

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,6 @@ export default tseslint.config(
         'error',
         { func: 2, constructor: 10 },
       ],
-      'max-lines-per-function': ['error', { max: 50, skipBlankLines: true }],
       'max-lines': ['error', { max: 250, skipBlankLines: true }],
       '@typescript-eslint/no-floating-promises': 'error',
       'no-magic-numbers': [
@@ -58,6 +57,19 @@ export default tseslint.config(
           ignoreArrayIndexes: true,
         },
       ],
+    },
+  },
+  // Have a higher max line limit for UI components
+  {
+    files: ['**/*.tsx'],
+    rules: {
+      'max-lines-per-function': ['error', { max: 150, skipBlankLines: true }],
+    },
+  },
+  {
+    files: ['**/*.ts'],
+    rules: {
+      'max-lines-per-function': ['error', { max: 50, skipBlankLines: true }],
     },
   },
   {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,7 @@
 /** @type {import('jest').Config} */
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   globals: {
     'ts-jest': {
       tsconfig: './tsconfig.test.json',

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "jest --config jest.config.cjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from './App'
+import type { PostcodeDataState } from './hooks/use-postcode-data'
+
+jest.mock('./hooks/use-postcode-data', () => ({
+  usePostcodeData: jest.fn(),
+}))
+
+import { usePostcodeData } from './hooks/use-postcode-data'
+const mockUsePostcodeData = usePostcodeData as jest.MockedFunction<typeof usePostcodeData>
+
+const idle: PostcodeDataState = { status: 'idle' }
+const loading: PostcodeDataState = { status: 'loading' }
+const fullSuccess: PostcodeDataState = {
+  status: 'success',
+  region: { name: 'East England', gspId: '_P' },
+  intensity: { actual: 150, band: 'moderate', updatedAt: '2024-01-01T12:00:00Z' },
+  generationMix: [{ fuel: 'wind', perc: 40 }, { fuel: 'gas', perc: 60 }],
+  unitRate: { value: 24.5, tariff: 'E-1R-VAR-22-11-01-P' },
+  aqi: { index: 2, level: 'fair', pm25: 8, no2: 15, o3: 60 },
+}
+
+beforeEach(() => {
+  mockUsePostcodeData.mockReturnValue(idle)
+})
+
+describe('App — landing state', () => {
+  it('renders navbar', () => {
+    render(<App />)
+    expect(screen.getByRole('navigation', { name: /main navigation/i })).toBeInTheDocument()
+  })
+
+  it('renders hero postcode form', () => {
+    render(<App />)
+    expect(screen.getByRole('search', { name: /postcode lookup/i })).toBeInTheDocument()
+  })
+
+  it('renders footer', () => {
+    render(<App />)
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument()
+  })
+
+  it('does not render dashboard cards', () => {
+    render(<App />)
+    expect(screen.queryByTestId('region-header')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('carbon-intensity-card')).not.toBeInTheDocument()
+  })
+})
+
+describe('App — results loading state', () => {
+  it('shows skeleton while loading', () => {
+    mockUsePostcodeData.mockReturnValue(loading)
+    render(<App />)
+    // submit a postcode to trigger results view
+    fireEvent.change(screen.getByRole('textbox', { name: /uk postcode/i }), {
+      target: { value: 'NR1 4AA' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /get electricity data/i }))
+    expect(screen.getByRole('status', { name: /loading results/i })).toBeInTheDocument()
+  })
+})
+
+describe('App — results success state', () => {
+  beforeEach(() => {
+    mockUsePostcodeData.mockReturnValue(fullSuccess)
+    render(<App />)
+    fireEvent.change(screen.getByRole('textbox', { name: /uk postcode/i }), {
+      target: { value: 'NR1 4AA' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /get electricity data/i }))
+  })
+
+  it('renders region header', () => {
+    expect(screen.getByTestId('region-header')).toBeInTheDocument()
+  })
+
+  it('renders carbon intensity card', () => {
+    expect(screen.getByTestId('carbon-intensity-card')).toBeInTheDocument()
+  })
+
+  it('renders generation mix card', () => {
+    expect(screen.getByTestId('generation-mix-card')).toBeInTheDocument()
+  })
+
+  it('renders air quality card', () => {
+    expect(screen.getByTestId('air-quality-card')).toBeInTheDocument()
+  })
+
+  it('renders unit rate card', () => {
+    expect(screen.getByTestId('unit-rate-card')).toBeInTheDocument()
+  })
+
+  it('renders cost breakdown card', () => {
+    expect(screen.getByTestId('cost-breakdown-card')).toBeInTheDocument()
+  })
+})
+
+describe('App — results partial state (missing data)', () => {
+  it('omits intensity card when intensity is undefined', () => {
+    mockUsePostcodeData.mockReturnValue({ ...fullSuccess, intensity: undefined })
+    render(<App />)
+    fireEvent.change(screen.getByRole('textbox', { name: /uk postcode/i }), {
+      target: { value: 'NR1 4AA' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /get electricity data/i }))
+    expect(screen.queryByTestId('carbon-intensity-card')).not.toBeInTheDocument()
+  })
+
+  it('omits cost breakdown when generationMix is undefined', () => {
+    mockUsePostcodeData.mockReturnValue({ ...fullSuccess, generationMix: undefined })
+    render(<App />)
+    fireEvent.change(screen.getByRole('textbox', { name: /uk postcode/i }), {
+      target: { value: 'NR1 4AA' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /get electricity data/i }))
+    expect(screen.queryByTestId('cost-breakdown-card')).not.toBeInTheDocument()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,122 +1,69 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from './assets/vite.svg'
-import heroImg from './assets/hero.png'
-import './App.css'
+import { Navbar } from './components/Navbar'
+import { Hero } from './components/Hero'
+import { Footer } from './components/Footer'
+import { Skeleton } from './components/Skeleton'
+import { RegionHeader } from './components/results/RegionHeader'
+import { CarbonIntensityCard } from './components/results/CarbonIntensityCard'
+import { GenerationMixCard } from './components/results/GenerationMixCard'
+import { AirQualityCard } from './components/results/AirQualityCard'
+import { UnitRateCard } from './components/results/UnitRateCard'
+import { CostBreakdownCard } from './components/results/CostBreakdownCard'
+import { usePostcodeData } from './hooks/use-postcode-data'
+import { LCOE } from './data/lcoe'
 
-// eslint-disable-next-line max-lines-per-function -- temporary Vite boilerplate, replaced in issue #33
-function App() {
-  const [count, setCount] = useState(0)
+export default function App() {
+  const [postcode, setPostcode] = useState('')
+  const data = usePostcodeData(postcode)
 
   return (
-    <>
-      <section id="center">
-        <div className="hero">
-          <img src={heroImg} className="base" width="170" height="179" alt="" />
-          <img src={reactLogo} className="framework" alt="React logo" />
-          <img src={viteLogo} className="vite" alt="Vite logo" />
-        </div>
-        <div>
-          <h1>Get started</h1>
-          <p>
-            Edit <code>src/App.tsx</code> and save to test <code>HMR</code>
-          </p>
-        </div>
-        <button
-          className="counter"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          Count is {count}
-        </button>
-      </section>
+    <div className="min-h-screen flex flex-col bg-[var(--color-bg)]">
+      <Navbar />
+      <main className="flex-1 w-full max-w-[1100px] mx-auto px-md py-xl">
+        <Hero onSubmit={setPostcode} />
 
-      <div className="ticks"></div>
+        {postcode && data.status === 'loading' && <Skeleton />}
 
-      <section id="next-steps">
-        <div id="docs">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
-          </svg>
-          <h2>Documentation</h2>
-          <p>Your questions, answered</p>
-          <ul>
-            <li>
-              <a href="https://vite.dev/" target="_blank">
-                <img className="logo" src={viteLogo} alt="" />
-                Explore Vite
-              </a>
-            </li>
-            <li>
-              <a href="https://react.dev/" target="_blank">
-                <img className="button-icon" src={reactLogo} alt="" />
-                Learn more
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div id="social">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
-          </svg>
-          <h2>Connect with us</h2>
-          <p>Join the Vite community</p>
-          <ul>
-            <li>
-              <a href="https://github.com/vitejs/vite" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#github-icon"></use>
-                </svg>
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a href="https://chat.vite.dev/" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#discord-icon"></use>
-                </svg>
-                Discord
-              </a>
-            </li>
-            <li>
-              <a href="https://x.com/vite_js" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#x-icon"></use>
-                </svg>
-                X.com
-              </a>
-            </li>
-            <li>
-              <a href="https://bsky.app/profile/vite.dev" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#bluesky-icon"></use>
-                </svg>
-                Bluesky
-              </a>
-            </li>
-          </ul>
-        </div>
-      </section>
+        {postcode && data.status !== 'loading' && (
+          <>
+            <RegionHeader
+              postcode={postcode}
+              regionName={data.region?.name ?? ''}
+              gspId={data.region?.gspId ?? ''}
+            />
 
-      <div className="ticks"></div>
-      <section id="spacer"></section>
-    </>
+            <h2 className="text-sm font-semibold text-text-secondary uppercase tracking-[0.08em] mt-xl mb-md">
+              Environmental data
+            </h2>
+
+            {data.intensity && (
+              <CarbonIntensityCard intensity={data.intensity} />
+            )}
+
+            <div className="grid lg:grid-cols-[3fr_2fr] gap-md mt-md">
+              {data.generationMix && (
+                <GenerationMixCard mix={data.generationMix} lcoe={LCOE} />
+              )}
+              {data.aqi && <AirQualityCard aqi={data.aqi} />}
+            </div>
+
+            <h2 className="text-sm font-semibold text-text-secondary uppercase tracking-[0.08em] mt-xl mb-md">
+              Price data
+            </h2>
+
+            {data.unitRate && <UnitRateCard unitRate={data.unitRate} />}
+
+            {data.generationMix && data.unitRate && (
+              <CostBreakdownCard
+                generationMix={data.generationMix}
+                lcoe={LCOE}
+                unitRate={data.unitRate.value}
+              />
+            )}
+          </>
+        )}
+      </main>
+      <Footer />
+    </div>
   )
 }
-
-export default App

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,60 +1,54 @@
 function NavLogo() {
   return (
     <svg
-      viewBox="0 0 28 28"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      className="w-7 h-7 shrink-0"
+      viewBox='0 0 28 28'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      aria-hidden='true'
+      className='w-7 h-7 shrink-0'
     >
-      <circle cx="14" cy="14" r="14" fill="rgba(45,139,139,0.2)" />
+      <circle cx='14' cy='14' r='14' fill='rgba(45,139,139,0.2)' />
       <path
-        d="M5 15 Q 9 11, 13 15 Q 17 19, 21 15"
-        stroke="#3aad63"
-        strokeWidth="1.8"
-        fill="none"
-        strokeLinecap="round"
+        d='M5 15 Q 9 11, 13 15 Q 17 19, 21 15'
+        stroke='#3aad63'
+        strokeWidth='1.8'
+        fill='none'
+        strokeLinecap='round'
       />
       <path
-        d="M5 18.5 Q 9 14.5, 13 18.5 Q 17 22.5, 21 18.5"
-        stroke="#3aad63"
-        strokeWidth="1.2"
-        fill="none"
-        strokeLinecap="round"
-        opacity="0.5"
+        d='M5 18.5 Q 9 14.5, 13 18.5 Q 17 22.5, 21 18.5'
+        stroke='#3aad63'
+        strokeWidth='1.2'
+        fill='none'
+        strokeLinecap='round'
+        opacity='0.5'
       />
       <path
-        d="M15.5 7 L12 13.5 L15 13.5 L12.5 20 L16 12.5 L13 12.5 Z"
-        fill="#f0a500"
-        opacity="0.95"
+        d='M15.5 7 L12 13.5 L15 13.5 L12.5 20 L16 12.5 L13 12.5 Z'
+        fill='#f0a500'
+        opacity='0.95'
       />
     </svg>
-  )
+  );
 }
 
 export function Navbar() {
   return (
     <nav
-      role="navigation"
-      aria-label="Main navigation"
-      className="w-full h-[60px] flex items-center justify-between px-md border-b border-border bg-[rgba(13,18,32,0.82)] backdrop-blur-lg sticky top-0 z-[100]"
+      role='navigation'
+      aria-label='Main navigation'
+      className='w-full h-[60px] flex items-center justify-between px-md border-b border-border bg-[rgba(13,18,32,0.82)] backdrop-blur-lg sticky top-0 z-[100]'
     >
       <a
-        href="#"
+        href='#'
         aria-label="What's Watt home"
-        className="flex items-center gap-sm no-underline"
+        className='flex items-center gap-sm no-underline'
       >
         <NavLogo />
-        <span className="font-display font-bold text-lg text-text-primary tracking-[-0.02em]">
-          What&apos;s<span className="text-brand-light">Watt</span>
+        <span className='font-display font-bold text-lg text-text-primary tracking-[-0.02em]'>
+          What&apos;s<span className='text-brand-light'>Watt</span>
         </span>
       </a>
-      <a
-        href="#"
-        className="text-sm font-medium text-text-secondary no-underline"
-      >
-        About
-      </a>
     </nav>
-  )
+  );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -49,6 +49,13 @@ export function Navbar() {
           What&apos;s<span className='text-brand-light'>Watt</span>
         </span>
       </a>
+      <a
+        href='#'
+        aria-label='About'
+        className='text-sm font-medium text-text-secondary hover:text-text-primary transition-colors'
+      >
+        About
+      </a>
     </nav>
   );
 }

--- a/src/components/results/AirQualityCard.tsx
+++ b/src/components/results/AirQualityCard.tsx
@@ -69,6 +69,7 @@ export function AirQualityCard({ aqi }: Readonly<Properties>) {
 
   return (
     <article
+      data-testid="air-quality-card"
       className="rounded-card p-lg border shadow-[0_2px_24px_rgba(0,0,0,0.32)]"
       style={{ background: `var(--color-aqi-${level}-bg)`, borderColor: `var(--color-aqi-${level}-border, var(--color-border))` }}
       aria-labelledby="aqi-heading"

--- a/src/components/results/AirQualityCard.tsx
+++ b/src/components/results/AirQualityCard.tsx
@@ -1,110 +1,176 @@
-import type { AqiLevel } from '../../utils/aqi-band'
+import type { AqiLevel } from '../../utils/aqi-band';
 
 interface AqiData {
-  readonly index: number
-  readonly level: AqiLevel
-  readonly pm25: number
-  readonly no2: number
-  readonly o3: number
+  readonly index: number;
+  readonly level: AqiLevel;
+  readonly pm25: number;
+  readonly no2: number;
+  readonly o3: number;
 }
 
 interface Properties {
-  readonly aqi: AqiData
+  readonly aqi: AqiData;
 }
 
-const LEVEL_ORDER: AqiLevel[] = ['good', 'fair', 'moderate', 'poor', 'very-poor']
+const LEVEL_ORDER: AqiLevel[] = [
+  'good',
+  'fair',
+  'moderate',
+  'poor',
+  'very-poor',
+];
 const LEVEL_LABELS: Record<AqiLevel, string> = {
   good: 'Good',
   fair: 'Fair',
   moderate: 'Moderate',
   poor: 'Poor',
   'very-poor': 'Very Poor',
-}
-const INACTIVE_OPACITY = 0.35
+};
+const INACTIVE_OPACITY = 0.35;
 
 function levelToIndex(level: AqiLevel): number {
-  return LEVEL_ORDER.indexOf(level) + 1
+  return LEVEL_ORDER.indexOf(level) + 1;
 }
 
-interface PollutantProperties { name: string; value: number; ariaLabel: string }
+interface PollutantProperties {
+  name: string;
+  value: number;
+  ariaLabel: string;
+}
 
-function PollutantTile({ name, value, ariaLabel }: Readonly<PollutantProperties>) {
+function PollutantTile({
+  name,
+  value,
+  ariaLabel,
+}: Readonly<PollutantProperties>) {
   return (
-    <div role="listitem" className="flex-1 min-w-[72px] bg-white/[0.04] border border-border rounded-button py-sm px-md">
-      <p className="text-xs font-semibold text-text-disabled uppercase tracking-[0.07em] mb-[3px]">{name}</p>
-      <p className="font-display text-lg font-bold text-text-primary tabular-nums tracking-[-0.02em]" aria-label={ariaLabel}>{value.toFixed(1)}</p>
-      <span className="text-xs text-text-disabled font-normal block mt-[1px]">µg/m³</span>
-    </div>
-  )
+    <li className='flex-1 min-w-[72px] bg-white/[0.04] border border-border rounded-button py-sm px-md'>
+      <p className='text-xs font-semibold text-text-disabled uppercase tracking-[0.07em] mb-[3px]'>
+        {name}
+      </p>
+      <p
+        className='font-display text-lg font-bold text-text-primary tabular-nums tracking-[-0.02em]'
+        aria-label={ariaLabel}
+      >
+        {value.toFixed(1)}
+      </p>
+      <span className='text-xs text-text-disabled font-normal block mt-[1px]'>
+        µg/m³
+      </span>
+    </li>
+  );
 }
 
-interface ScaleBarProperties { readonly activeIndex: number }
+interface ScaleBarProperties {
+  readonly activeIndex: number;
+}
 
 function ScaleBar({ activeIndex }: Readonly<ScaleBarProperties>) {
   return (
     <>
-      <div className="flex gap-[3px] h-[6px] rounded-[3px] overflow-hidden mb-xs" aria-hidden="true">
+      <div
+        className='flex gap-[3px] h-[6px] rounded-[3px] overflow-hidden mb-xs'
+        aria-hidden='true'
+      >
         {LEVEL_ORDER.map((lvl, segmentIndex) => (
           <div
             key={lvl}
             data-testid={`aqi-seg-${segmentIndex + 1}`}
-            className="flex-1 rounded-[2px]"
-            style={{ background: `var(--color-aqi-${lvl})`, opacity: segmentIndex + 1 === activeIndex ? 1 : INACTIVE_OPACITY }}
+            className='flex-1 rounded-[2px]'
+            style={{
+              background: `var(--color-aqi-${lvl})`,
+              opacity: segmentIndex + 1 === activeIndex ? 1 : INACTIVE_OPACITY,
+            }}
           />
         ))}
       </div>
-      <div className="flex justify-between mb-md" aria-hidden="true">
-        <span className="text-xs text-text-disabled font-medium">Good</span>
-        <span className="text-xs text-text-disabled font-medium">Very Poor</span>
+      <div className='flex justify-between mb-md' aria-hidden='true'>
+        <span className='text-xs text-text-disabled font-medium'>Good</span>
+        <span className='text-xs text-text-disabled font-medium'>
+          Very Poor
+        </span>
       </div>
     </>
-  )
+  );
 }
 
 export function AirQualityCard({ aqi }: Readonly<Properties>) {
-  const { level, pm25, no2, o3 } = aqi
-  const displayIndex = levelToIndex(level)
-  const label = LEVEL_LABELS[level]
-  const colour = `var(--color-aqi-${level})`
+  const { level, pm25, no2, o3 } = aqi;
+  const displayIndex = levelToIndex(level);
+  const label = LEVEL_LABELS[level];
+  const colour = `var(--color-aqi-${level})`;
 
   return (
     <article
-      data-testid="air-quality-card"
-      className="rounded-card p-lg border shadow-[0_2px_24px_rgba(0,0,0,0.32)]"
-      style={{ background: `var(--color-aqi-${level}-bg)`, borderColor: `var(--color-aqi-${level}-border, var(--color-border))` }}
-      aria-labelledby="aqi-heading"
+      data-testid='air-quality-card'
+      className='rounded-card p-lg border shadow-[0_2px_24px_rgba(0,0,0,0.32)]'
+      style={{
+        background: `var(--color-aqi-${level}-bg)`,
+        borderColor: `var(--color-aqi-${level}-border, var(--color-border))`,
+      }}
+      aria-labelledby='aqi-heading'
     >
-      <div className="flex items-center justify-between mb-md">
-        <span className="text-base font-semibold text-text-primary" id="aqi-heading">Air Quality</span>
+      <div className='flex items-center justify-between mb-md'>
+        <span
+          className='text-base font-semibold text-text-primary'
+          id='aqi-heading'
+        >
+          Air Quality
+        </span>
         <div
-          role="img"
+          role='img'
           aria-label={`Air quality: ${label}`}
-          className="inline-flex items-center gap-[5px] px-3 py-1 rounded-pill text-white text-xs font-bold tracking-[0.06em] uppercase"
+          className='inline-flex items-center gap-[5px] px-3 py-1 rounded-pill text-white text-xs font-bold tracking-[0.06em] uppercase'
           style={{ background: colour }}
         >
-          <span aria-hidden="true" className="w-[6px] h-[6px] rounded-full bg-white/60 inline-block" />
+          <span
+            aria-hidden='true'
+            className='w-[6px] h-[6px] rounded-full bg-white/60 inline-block'
+          />
           {label}
         </div>
       </div>
 
-      <div className="flex items-baseline gap-sm mb-md">
+      <div className='flex items-baseline gap-sm mb-md'>
         <span
-          className="font-display text-[3.5rem] font-extrabold leading-none tabular-nums tracking-[-0.04em]"
+          className='font-display text-[3.5rem] font-extrabold leading-none tabular-nums tracking-[-0.04em]'
           style={{ color: colour }}
           aria-label={`European AQI ${displayIndex}`}
         >
           {displayIndex}
         </span>
-        <span aria-hidden="true" className="text-lg font-semibold" style={{ color: colour }}>/ 5</span>
+        <span
+          aria-hidden='true'
+          className='text-lg font-semibold'
+          style={{ color: colour }}
+        >
+          / 5
+        </span>
       </div>
 
       <ScaleBar activeIndex={displayIndex} />
 
-      <div role="list" aria-label="Key pollutants" className="flex gap-md flex-wrap">
-        <PollutantTile name="PM2.5" value={pm25} ariaLabel={`${pm25.toFixed(1)} micrograms per cubic metre`} />
-        <PollutantTile name="NO₂" value={no2} ariaLabel={`${no2.toFixed(1)} micrograms per cubic metre`} />
-        <PollutantTile name="O₃" value={o3} ariaLabel={`${o3.toFixed(1)} micrograms per cubic metre`} />
+      <div
+        role='list'
+        aria-label='Key pollutants'
+        className='flex gap-md flex-wrap'
+      >
+        <PollutantTile
+          name='PM2.5'
+          value={pm25}
+          ariaLabel={`${pm25.toFixed(1)} micrograms per cubic metre`}
+        />
+        <PollutantTile
+          name='NO₂'
+          value={no2}
+          ariaLabel={`${no2.toFixed(1)} micrograms per cubic metre`}
+        />
+        <PollutantTile
+          name='O₃'
+          value={o3}
+          ariaLabel={`${o3.toFixed(1)} micrograms per cubic metre`}
+        />
       </div>
     </article>
-  )
+  );
 }

--- a/src/components/results/AirQualityCard.tsx
+++ b/src/components/results/AirQualityCard.tsx
@@ -19,13 +19,6 @@ const LEVEL_ORDER: AqiLevel[] = [
   'poor',
   'very-poor',
 ];
-const LEVEL_LABELS: Record<AqiLevel, string> = {
-  good: 'Good',
-  fair: 'Fair',
-  moderate: 'Moderate',
-  poor: 'Poor',
-  'very-poor': 'Very Poor',
-};
 const INACTIVE_OPACITY = 0.35;
 
 function levelToIndex(level: AqiLevel): number {
@@ -94,10 +87,66 @@ function ScaleBar({ activeIndex }: Readonly<ScaleBarProperties>) {
   );
 }
 
+interface AqiHeaderProperties {
+  readonly label: string;
+  readonly colour: string;
+}
+
+function AqiHeader({ label, colour }: Readonly<AqiHeaderProperties>) {
+  return (
+    <div className='flex items-center justify-between mb-md'>
+      <span
+        className='text-base font-semibold text-text-primary'
+        id='aqi-heading'
+      >
+        Air Quality
+      </span>
+      <div
+        role='img'
+        aria-label={`Air quality: ${label}`}
+        className='inline-flex items-center gap-[5px] px-3 py-1 rounded-pill text-white text-xs font-bold tracking-[0.06em] uppercase'
+        style={{ background: colour }}
+      >
+        <span
+          aria-hidden='true'
+          className='w-[6px] h-[6px] rounded-full bg-white/60 inline-block'
+        />
+        {label}
+      </div>
+    </div>
+  );
+}
+
+interface AqiNumberProperties {
+  readonly displayIndex: number;
+  readonly colour: string;
+}
+
+function AqiNumber({ displayIndex, colour }: Readonly<AqiNumberProperties>) {
+  return (
+    <div className='flex items-baseline gap-sm mb-md'>
+      <span
+        className='font-display text-[3.5rem] font-extrabold leading-none tabular-nums tracking-[-0.04em]'
+        style={{ color: colour }}
+        aria-label={`European AQI ${displayIndex}`}
+      >
+        {displayIndex}
+      </span>
+      <span
+        aria-hidden='true'
+        className='text-lg font-semibold'
+        style={{ color: colour }}
+      >
+        / 5
+      </span>
+    </div>
+  );
+}
+
 export function AirQualityCard({ aqi }: Readonly<Properties>) {
   const { level, pm25, no2, o3 } = aqi;
   const displayIndex = levelToIndex(level);
-  const label = LEVEL_LABELS[level];
+  const label = level.toLocaleUpperCase();
   const colour = `var(--color-aqi-${level})`;
 
   return (
@@ -110,51 +159,10 @@ export function AirQualityCard({ aqi }: Readonly<Properties>) {
       }}
       aria-labelledby='aqi-heading'
     >
-      <div className='flex items-center justify-between mb-md'>
-        <span
-          className='text-base font-semibold text-text-primary'
-          id='aqi-heading'
-        >
-          Air Quality
-        </span>
-        <div
-          role='img'
-          aria-label={`Air quality: ${label}`}
-          className='inline-flex items-center gap-[5px] px-3 py-1 rounded-pill text-white text-xs font-bold tracking-[0.06em] uppercase'
-          style={{ background: colour }}
-        >
-          <span
-            aria-hidden='true'
-            className='w-[6px] h-[6px] rounded-full bg-white/60 inline-block'
-          />
-          {label}
-        </div>
-      </div>
-
-      <div className='flex items-baseline gap-sm mb-md'>
-        <span
-          className='font-display text-[3.5rem] font-extrabold leading-none tabular-nums tracking-[-0.04em]'
-          style={{ color: colour }}
-          aria-label={`European AQI ${displayIndex}`}
-        >
-          {displayIndex}
-        </span>
-        <span
-          aria-hidden='true'
-          className='text-lg font-semibold'
-          style={{ color: colour }}
-        >
-          / 5
-        </span>
-      </div>
-
+      <AqiHeader label={label} colour={colour} />
+      <AqiNumber displayIndex={displayIndex} colour={colour} />
       <ScaleBar activeIndex={displayIndex} />
-
-      <div
-        role='list'
-        aria-label='Key pollutants'
-        className='flex gap-md flex-wrap'
-      >
+      <ul aria-label='Key pollutants' className='flex gap-md flex-wrap'>
         <PollutantTile
           name='PM2.5'
           value={pm25}
@@ -170,7 +178,7 @@ export function AirQualityCard({ aqi }: Readonly<Properties>) {
           value={o3}
           ariaLabel={`${o3.toFixed(1)} micrograms per cubic metre`}
         />
-      </div>
+      </ul>
     </article>
   );
 }

--- a/src/components/results/AirQualityCard.tsx
+++ b/src/components/results/AirQualityCard.tsx
@@ -19,6 +19,28 @@ const LEVEL_ORDER: AqiLevel[] = [
   'poor',
   'very-poor',
 ];
+type LevelLabel = 'Good' | 'Fair' | 'Moderate' | 'Poor' | 'Very Poor';
+
+const getLevelLabels = (level: AqiLevel): LevelLabel => {
+  switch (level) {
+    case 'fair': {
+      return 'Fair';
+    }
+    case 'moderate': {
+      return 'Moderate';
+    }
+    case 'good': {
+      return 'Good';
+    }
+    case 'poor': {
+      return 'Poor';
+    }
+    case 'very-poor': {
+      return 'Very Poor';
+    }
+  }
+};
+
 const INACTIVE_OPACITY = 0.35;
 
 function levelToIndex(level: AqiLevel): number {
@@ -146,7 +168,7 @@ function AqiNumber({ displayIndex, colour }: Readonly<AqiNumberProperties>) {
 export function AirQualityCard({ aqi }: Readonly<Properties>) {
   const { level, pm25, no2, o3 } = aqi;
   const displayIndex = levelToIndex(level);
-  const label = level.toLocaleUpperCase();
+  const label = getLevelLabels(level);
   const colour = `var(--color-aqi-${level})`;
 
   return (

--- a/src/components/results/CarbonIntensityCard.tsx
+++ b/src/components/results/CarbonIntensityCard.tsx
@@ -87,6 +87,7 @@ export function CarbonIntensityCard({ intensity }: Properties) {
 
   return (
     <article
+      data-testid="carbon-intensity-card"
       aria-labelledby="intensity-heading"
       className="relative overflow-hidden rounded-[var(--radius-card)] p-[var(--space-lg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_4px_32px_rgba(0,0,0,0.45)]"
       style={{ background: bgToken, border: `1px solid ${borderToken}` }}

--- a/src/components/results/CostBreakdownCard.tsx
+++ b/src/components/results/CostBreakdownCard.tsx
@@ -1,0 +1,21 @@
+// stub — replaced by PR #32 (CostBreakdownCard full implementation)
+import type { LCOE as LcoeType } from '../../data/lcoe'
+
+interface Properties {
+  readonly generationMix: Array<{ fuel: string; perc: number }>
+  readonly lcoe: typeof LcoeType
+  readonly unitRate: number
+}
+
+export function CostBreakdownCard({ generationMix, lcoe, unitRate }: Readonly<Properties>) {
+  return (
+    <article data-testid="cost-breakdown-card">
+      <p>{unitRate}p/kWh</p>
+      <ul>
+        {generationMix.map(({ fuel, perc }) => (
+          <li key={fuel}>{lcoe[fuel]?.label ?? fuel}: {perc}%</li>
+        ))}
+      </ul>
+    </article>
+  )
+}

--- a/src/components/results/CostBreakdownCard.tsx
+++ b/src/components/results/CostBreakdownCard.tsx
@@ -141,6 +141,7 @@ export function CostBreakdownCard({ generationMix, lcoe }: Properties) {
 
   return (
     <article
+      data-testid="cost-breakdown-card"
       aria-labelledby="cost-break-heading"
       className="rounded-[var(--radius-card)] p-[var(--space-lg)] shadow-[0_2px_24px_rgba(0,0,0,0.32)]"
       style={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)' }}

--- a/src/components/results/GenerationMixCard.tsx
+++ b/src/components/results/GenerationMixCard.tsx
@@ -97,7 +97,7 @@ const MIX_ICON = (
 export function GenerationMixCard({ mix, lcoe }: Properties) {
   const sorted = mix.toSorted((a, b) => b.perc - a.perc)
   return (
-    <article style={CARD_STYLE}>
+    <article data-testid="generation-mix-card" style={CARD_STYLE}>
       <h2 style={HEADING_STYLE}>{MIX_ICON}Generation Mix</h2>
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)' }}>
         <DonutChart sorted={sorted} lcoe={lcoe} />

--- a/src/components/results/RegionHeader.tsx
+++ b/src/components/results/RegionHeader.tsx
@@ -7,7 +7,7 @@ interface Properties {
 export function RegionHeader({ postcode, regionName, gspId }: Properties) {
   const gspLetter = gspId.startsWith('_') ? gspId.slice(1) : gspId
   return (
-    <p>
+    <p data-testid="region-header">
       {postcode} · {regionName} · GSP Region {gspLetter}
     </p>
   )

--- a/src/components/results/UnitRateCard.tsx
+++ b/src/components/results/UnitRateCard.tsx
@@ -12,6 +12,7 @@ export function UnitRateCard({ unitRate }: Readonly<Properties>) {
 
   return (
     <article
+      data-testid="unit-rate-card"
       className="rounded-card p-lg bg-surface-raised border border-border shadow-[0_2px_24px_rgba(0,0,0,0.32)]"
       aria-labelledby="unit-rate-heading"
     >


### PR DESCRIPTION
Closes 33. Replaces Vite boilerplate with real What's Watt layout. Landing: Navbar+Hero+Footer. Results: RegionHeader+all 5 cards+skeleton while loading. Desktop 3fr/2fr grid at lg breakpoint. Cards omitted when data undefined. Adds data-testid to card roots. Includes CostBreakdownCard stub (correct interface) — full impl in PR 76 (issue 32), merge after. Visual review pending Playwright permission grant.