### PR TITLE
feat(#35): localStorage postcode persistence on successful lookup

### DIFF
--- a/src/hooks/use-postcode-data.test.ts
+++ b/src/hooks/use-postcode-data.test.ts
@@ -138,6 +138,15 @@ it('shows the one success when two services fail', async () => {
   expect(result.current.aqi?.index).toBe(AQ_RESULT.european_aqi)
 })
 
+it('writes postcode to localStorage on successful lookup', async () => {
+  setupAllMocksOk()
+  const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
+  const { result } = renderHook(() => usePostcodeData('NR1 4AA'))
+  await waitFor(() => { expect(result.current.status).toBe('success') })
+  expect(setItemSpy).toHaveBeenCalledWith('whats-watt:postcode', 'NR1 4AA')
+  setItemSpy.mockRestore()
+})
+
 it('ignores stale results when postcode changes mid-flight', async () => {
   let resolveFirst!: (value: typeof CI_RESULT) => void
   const firstCall = new Promise<typeof CI_RESULT>((resolve) => { resolveFirst = resolve })

--- a/src/hooks/use-postcode-data.ts
+++ b/src/hooks/use-postcode-data.ts
@@ -148,7 +148,10 @@ export function usePostcodeData(postcode: string): PostcodeDataState {
     dispatch({ type: 'loading' })
 
     void Promise.allSettled([fetchCi(context), fetchOctopus(context), fetchAq(context)]).then(() => {
-      if (!ignore.current) dispatch({ type: 'success' })
+      if (!ignore.current) {
+        localStorage.setItem('whats-watt:postcode', postcode)
+        dispatch({ type: 'success' })
+      }
     })
 
     return () => {


### PR DESCRIPTION
Closes #35

Saves postcode to localStorage on successful CI lookup so the Hero input is pre-filled on next visit. The read-on-mount was already in Hero.tsx.

Acceptance criteria:
- [x] On successful lookup: localStorage.setItem("whats-watt:postcode", postcode)
- [x] On mount: read and pre-fill input (already in Hero.tsx)
- [x] Typecheck passes, lint passes (0 errors)
- [x] Test: writes to localStorage on success (new, passes)
