### PR TITLE
feat(e2e): invalid postcode E2E spec

### DIFF
--- a/e2e/invalid-postcode.spec.ts
+++ b/e2e/invalid-postcode.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+test('invalid postcode: ZZZZZ → inline error shown, no cards rendered', async ({ page }) => {
+  await page.goto('/')
+
+  await page.getByLabel('UK postcode').fill('ZZZZZ')
+  await page.getByRole('button', { name: /get electricity data/i }).click()
+
+  // Inline error alert should appear
+  await expect(page.getByRole('alert')).toBeVisible()
+  await expect(page.getByRole('alert')).toContainText(/valid UK postcode/i)
+
+  // No result cards should be rendered
+  await expect(page.getByTestId('carbon-intensity-card')).toBeHidden()
+  await expect(page.getByTestId('generation-mix-card')).toBeHidden()
+  await expect(page.getByTestId('air-quality-card')).toBeHidden()
+  await expect(page.getByTestId('unit-rate-card')).toBeHidden()
+  await expect(page.getByTestId('cost-breakdown-card')).toBeHidden()
+})

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -13,7 +13,7 @@ jest.mock('./hooks/use-postcode-data', () => ({
 import { usePostcodeData } from './hooks/use-postcode-data'
 const mockUsePostcodeData = usePostcodeData as jest.MockedFunction<typeof usePostcodeData>
 
-const noop = () => undefined
+const noop = () => {}
 const idle: PostcodeDataState = { status: 'idle', refetch: noop }
 const loading: PostcodeDataState = { status: 'loading', refetch: noop }
 const fullSuccess: PostcodeDataState = {


### PR DESCRIPTION
Closes #37. E2E spec: ZZZZZ -> inline error shown, no cards rendered. Uses toBeHidden() per playwright ESLint rule. Also fixes pre-existing unicorn/no-useless-undefined in App.test.tsx. AC: [x] inline error shown [x] no cards rendered [x] ESLint 0 errors [x] Jest 136/136 pass