### PR TITLE
fix: RegionHeader two-column layout, fonts, colour, spacing

### DIFF
--- a/src/components/results/RegionHeader.test.tsx
+++ b/src/components/results/RegionHeader.test.tsx
@@ -3,18 +3,23 @@ import { render, screen } from '@testing-library/react'
 import { RegionHeader } from './RegionHeader'
 
 describe('RegionHeader', () => {
-  it('renders postcode, region name, and GSP letter joined by middle dots', () => {
+  it('renders postcode in left element', () => {
     render(<RegionHeader postcode="NR1 4AA" regionName="East England" gspId="_P" />)
-    expect(screen.getByText('NR1 4AA · East England · GSP Region P')).toBeInTheDocument()
+    expect(screen.getByTestId('region-header-postcode')).toHaveTextContent('NR1 4AA')
+  })
+
+  it('renders region name and GSP letter in right element', () => {
+    render(<RegionHeader postcode="NR1 4AA" regionName="East England" gspId="_P" />)
+    expect(screen.getByTestId('region-header-region')).toHaveTextContent('East England · GSP Region P')
   })
 
   it('strips leading underscore from gspId', () => {
     render(<RegionHeader postcode="SW1A 1AA" regionName="South East" gspId="_J" />)
-    expect(screen.getByText('SW1A 1AA · South East · GSP Region J')).toBeInTheDocument()
+    expect(screen.getByTestId('region-header-region')).toHaveTextContent('GSP Region J')
   })
 
   it('handles gspId without underscore prefix', () => {
     render(<RegionHeader postcode="M1 1AE" regionName="North West" gspId="A" />)
-    expect(screen.getByText('M1 1AE · North West · GSP Region A')).toBeInTheDocument()
+    expect(screen.getByTestId('region-header-region')).toHaveTextContent('GSP Region A')
   })
 })

--- a/src/components/results/RegionHeader.tsx
+++ b/src/components/results/RegionHeader.tsx
@@ -7,8 +7,40 @@ interface Properties {
 export function RegionHeader({ postcode, regionName, gspId }: Properties) {
   const gspLetter = gspId.startsWith('_') ? gspId.slice(1) : gspId
   return (
-    <p data-testid="region-header">
-      {postcode} · {regionName} · GSP Region {gspLetter}
-    </p>
+    <div
+      data-testid="region-header"
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: 'var(--space-sm) 0',
+        fontFamily: 'var(--font-body)',
+        fontSize: 'var(--text-sm)',
+        color: 'var(--color-text-secondary)',
+      }}
+    >
+      <span
+        data-testid="region-header-postcode"
+        style={{
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
+        }}
+      >
+        {postcode}
+      </span>
+      <span
+        data-testid="region-header-region"
+        style={{
+          fontWeight: 500,
+          maxWidth: '180px',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {regionName} · GSP Region {gspLetter}
+      </span>
+    </div>
   )
 }


### PR DESCRIPTION
Closes #86

## Changes
- Two-column flex layout: postcode left (weight 600, uppercase, letter-spacing 0.1em), region+GSP right (weight 500, max-width 180px, ellipsis)
- Container: flex row, space-between, 8px vertical padding
- Font: Plus Jakarta Sans via `--font-body`

## Test plan
- [ ] 4 RegionHeader tests pass
- [ ] No ESLint errors / TS errors
- [ ] Visual QA against mockup

🤖 Generated with [Claude Code](https://claude.com/claude-code)