### PR TITLE
fix(#87): load Plus Jakarta Sans, fix hero number font utilities

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,6 +27,16 @@ beforeEach(() => {
   mockUsePostcodeData.mockReturnValue(idle)
 })
 
+describe('App — postcode persistence', () => {
+  it('restores saved postcode from localStorage on mount', () => {
+    localStorage.setItem('whats-watt:postcode', 'NR1 4AA')
+    mockUsePostcodeData.mockReturnValue(fullSuccess)
+    render(<App />)
+    expect(mockUsePostcodeData).toHaveBeenCalledWith('NR1 4AA')
+    localStorage.removeItem('whats-watt:postcode')
+  })
+})
+
 describe('App — landing state', () => {
   it('renders navbar', () => {
     render(<App />)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,7 @@ export default function App() {
                 type='button'
                 onClick={data.refetch}
                 aria-label='Refresh data'
-                className='flex items-center gap-xs text-[var(--text-xs)] font-medium text-[var(--color-text-disabled)] hover:text-[var(--color-brand-light)] cursor-pointer bg-transparent border-none transition-colors'
+                className='flex items-center gap-xs text-xs font-medium text-[var(--color-text-disabled)] hover:text-[var(--color-brand-light)] cursor-pointer bg-transparent border-none transition-colors'
               >
                 {REFRESH_ICON}
                 Refresh

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ const REFRESH_ICON = (
 )
 
 export default function App() {
-  const [postcode, setPostcode] = useState('')
+  const [postcode, setPostcode] = useState(() => localStorage.getItem('whats-watt:postcode') ?? '')
   const data = usePostcodeData(postcode)
 
   const allApiFailed = Boolean(data.intensityError && data.unitRateError && data.aqiError)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,57 @@
-import { useState } from 'react'
-import { Primitive } from '@radix-ui/react-primitive'
-import { Navbar } from './components/Navbar'
-import { Hero } from './components/Hero'
-import { Footer } from './components/Footer'
-import { Skeleton } from './components/Skeleton'
-import { NetworkBanner } from './components/NetworkBanner'
-import { RegionHeader } from './components/results/RegionHeader'
-import { CarbonIntensityCard } from './components/results/CarbonIntensityCard'
-import { GenerationMixCard } from './components/results/GenerationMixCard'
-import { AirQualityCard } from './components/results/AirQualityCard'
-import { UnitRateCard } from './components/results/UnitRateCard'
-import { CostBreakdownCard } from './components/results/CostBreakdownCard'
-import { usePostcodeData } from './hooks/use-postcode-data'
-import { LCOE } from './data/lcoe'
+import { useState } from 'react';
+import { Primitive } from '@radix-ui/react-primitive';
+import { Navbar } from './components/Navbar';
+import { Hero } from './components/Hero';
+import { Footer } from './components/Footer';
+import { Skeleton } from './components/Skeleton';
+import { NetworkBanner } from './components/NetworkBanner';
+import { RegionHeader } from './components/results/RegionHeader';
+import { CarbonIntensityCard } from './components/results/CarbonIntensityCard';
+import { GenerationMixCard } from './components/results/GenerationMixCard';
+import { AirQualityCard } from './components/results/AirQualityCard';
+import { UnitRateCard } from './components/results/UnitRateCard';
+import { CostBreakdownCard } from './components/results/CostBreakdownCard';
+import { usePostcodeData } from './hooks/use-postcode-data';
+import { LCOE } from './data/lcoe';
 
 const REFRESH_ICON = (
-  <svg viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" className="w-3 h-3">
-    <path d="M10.5 6 A4.5 4.5 0 1 1 8.5 2.2 L10.5 2.2 M10.5 2.2 L10.5 4.2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+  <svg
+    viewBox='0 0 12 12'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    aria-hidden='true'
+    className='w-3 h-3'
+  >
+    <path
+      d='M10.5 6 A4.5 4.5 0 1 1 8.5 2.2 L10.5 2.2 M10.5 2.2 L10.5 4.2'
+      stroke='currentColor'
+      strokeWidth='1.2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    />
   </svg>
-)
+);
 
 export default function App() {
-  const [postcode, setPostcode] = useState(() => localStorage.getItem('whats-watt:postcode') ?? '')
-  const data = usePostcodeData(postcode)
+  const [postcode, setPostcode] = useState(
+    () => localStorage.getItem('whats-watt:postcode') ?? '',
+  );
+  const data = usePostcodeData(postcode);
 
-  const allApiFailed = Boolean(data.intensityError && data.unitRateError && data.aqiError)
+  const allApiFailed = Boolean(
+    data.intensityError && data.unitRateError && data.aqiError,
+  );
+
+  const beforeForSectionTitles =
+    'before:content-[""] before:w-[3px] before:h-[14px] before:rounded-[2px] before:bg-[var(--color-brand)] before:shrink-0';
 
   return (
-    <div className="min-h-screen flex flex-col bg-[var(--color-bg)]">
+    <div className='min-h-screen flex flex-col bg-[var(--color-bg)]'>
       <Navbar />
-      <main className="flex-1 w-full max-w-[1100px] mx-auto px-md py-xl">
+      <main className='flex-1 w-full max-w-[1100px] mx-auto px-4 sm:px-6 lg:px-16 pb-16'>
         <Hero onSubmit={setPostcode} />
 
-        {postcode && allApiFailed && (
-          <NetworkBanner onRetry={data.refetch} />
-        )}
+        {postcode && allApiFailed && <NetworkBanner onRetry={data.refetch} />}
 
         {postcode && data.status === 'loading' && <Skeleton />}
 
@@ -46,19 +63,23 @@ export default function App() {
               gspId={data.region?.gspId ?? ''}
             />
 
-            <h2 className="text-sm font-semibold text-text-secondary uppercase tracking-[0.08em] mt-xl mb-md">
-              Environmental data
+            <h2
+              className={`flex items-center gap-2 text-xs font-semibold text-text-secondary uppercase tracking-[0.08em] mt-10 mb-4 ${beforeForSectionTitles}`}
+            >
+              Environment
             </h2>
 
             {(data.intensity || data.intensityError) && (
               <CarbonIntensityCard
-                intensity={data.intensity ?? { actual: 0, band: 'low', updatedAt: '' }}
+                intensity={
+                  data.intensity ?? { actual: 0, band: 'low', updatedAt: '' }
+                }
                 error={data.intensityError}
                 onRetry={data.refetch}
               />
             )}
 
-            <div className="grid lg:grid-cols-[3fr_2fr] gap-md mt-md">
+            <div className='grid lg:grid-cols-[3fr_2fr] gap-md mt-md'>
               {(data.generationMix || data.intensityError) && (
                 <GenerationMixCard
                   mix={data.generationMix ?? []}
@@ -69,14 +90,22 @@ export default function App() {
               )}
               {(data.aqi || data.aqiError) && (
                 <AirQualityCard
-                  aqi={data.aqi ?? { index: 0, level: 'good', pm25: 0, no2: 0, o3: 0 }}
+                  aqi={
+                    data.aqi ?? {
+                      index: 0,
+                      level: 'good',
+                      pm25: 0,
+                      no2: 0,
+                      o3: 0,
+                    }
+                  }
                   error={data.aqiError}
                   onRetry={data.refetch}
                 />
               )}
             </div>
 
-            <h2 className="text-sm font-semibold text-text-secondary uppercase tracking-[0.08em] mt-xl mb-md">
+            <h2 className='text-sm font-semibold text-text-secondary uppercase tracking-[0.08em] mt-xl mb-md before:content-[""] before:w-[3px] before:h-[14px] before:rounded-[2px] before:bg-[var(--color-brand)] before:shrink-0'>
               Price data
             </h2>
 
@@ -96,12 +125,12 @@ export default function App() {
               />
             )}
 
-            <div className="flex items-center justify-center py-sm mt-md">
+            <div className='flex items-center justify-center py-sm mt-md'>
               <Primitive.button
-                type="button"
+                type='button'
                 onClick={data.refetch}
-                aria-label="Refresh data"
-                className="flex items-center gap-xs text-[var(--text-xs)] font-medium text-[var(--color-text-disabled)] hover:text-[var(--color-brand-light)] cursor-pointer bg-transparent border-none transition-colors"
+                aria-label='Refresh data'
+                className='flex items-center gap-xs text-[var(--text-xs)] font-medium text-[var(--color-text-disabled)] hover:text-[var(--color-brand-light)] cursor-pointer bg-transparent border-none transition-colors'
               >
                 {REFRESH_ICON}
                 Refresh
@@ -112,5 +141,5 @@ export default function App() {
       </main>
       <Footer />
     </div>
-  )
+  );
 }

--- a/src/components/results/CarbonIntensityCard.test.tsx
+++ b/src/components/results/CarbonIntensityCard.test.tsx
@@ -11,7 +11,13 @@ const baseIntensity = {
 describe('CarbonIntensityCard', () => {
   it('renders the actual value as the hero number', () => {
     render(<CarbonIntensityCard intensity={baseIntensity} />)
-    expect(screen.getByLabelText('142 grams CO2 per kilowatt-hour')).toBeInTheDocument()
+    expect(screen.getByLabelText('142 grams CO2 per kilowatt-hour')).toHaveTextContent('142')
+  })
+
+  it('applies font-feature-settings tnum to the hero number', () => {
+    render(<CarbonIntensityCard intensity={baseIntensity} />)
+    const heroSpan = screen.getByLabelText('142 grams CO2 per kilowatt-hour') as HTMLElement
+    expect(heroSpan.style.fontFeatureSettings).toBe("'tnum'")
   })
 
   it('renders the correct band badge text and aria-label', () => {

--- a/src/components/results/CarbonIntensityCard.tsx
+++ b/src/components/results/CarbonIntensityCard.tsx
@@ -119,9 +119,9 @@ export function CarbonIntensityCard({ intensity, error, onRetry }: Properties) {
       </div>
       <div className="flex items-baseline gap-[var(--space-sm)] mb-[var(--space-sm)]">
         <span
-          className="font-[var(--font-display)] text-[var(--text-hero)] font-extrabold leading-none tabular-nums tracking-[-0.04em]"
+          className="font-display text-hero font-extrabold leading-none tabular-nums tracking-[-0.04em]"
           aria-label={`${intensity.actual} grams CO2 per kilowatt-hour`}
-          style={{ color: colorToken }}
+          style={{ color: colorToken, fontFeatureSettings: "'tnum'" }}
         >
           {intensity.actual}
         </span>

--- a/src/components/results/CarbonIntensityCard.tsx
+++ b/src/components/results/CarbonIntensityCard.tsx
@@ -1,71 +1,77 @@
-import { Primitive } from '@radix-ui/react-primitive'
+import { Primitive } from '@radix-ui/react-primitive';
 
-const MAX_INTENSITY = 300
-const PERCENT_SCALE = 100
+const MAX_INTENSITY = 300;
+const PERCENT_SCALE = 100;
 
 interface Intensity {
-  actual: number
-  band: 'low' | 'moderate' | 'high'
-  updatedAt: string
+  actual: number;
+  band: 'low' | 'moderate' | 'high';
+  updatedAt: string;
 }
 
 interface Properties {
-  readonly intensity: Intensity
-  readonly error?: Error
-  readonly onRetry?: () => void
+  readonly intensity: Intensity;
+  readonly error?: Error;
+  readonly onRetry?: () => void;
 }
 
 function bandLabel(band: Intensity['band']): string {
-  if (band === 'low') return 'Low'
-  if (band === 'moderate') return 'Moderate'
-  return 'High'
+  if (band === 'low') return 'Low';
+  if (band === 'moderate') return 'Moderate';
+  return 'High';
 }
 
 const timeFormatter = new Intl.DateTimeFormat('en-GB', {
   hour: '2-digit',
   minute: '2-digit',
   timeZone: 'Europe/London',
-})
+});
 
 interface BadgeProperties {
-  readonly band: Intensity['band']
-  readonly colorToken: string
+  readonly band: Intensity['band'];
+  readonly colorToken: string;
 }
 
 function IntensityBadge({ band, colorToken }: BadgeProperties) {
-  const label = bandLabel(band)
+  const label = bandLabel(band);
   return (
     <div
-      role="img"
+      role='img'
       aria-label={`Intensity level: ${label}`}
-      className="inline-flex items-center gap-[5px] px-3 py-1 rounded-[var(--radius-pill)] text-white text-[var(--text-xs)] font-bold uppercase tracking-[0.06em]"
+      className='inline-flex items-center gap-[5px] px-3 py-1 rounded-[var(--radius-pill)] text-white text-xs font-bold uppercase tracking-[0.06em]'
       style={{ background: colorToken }}
     >
-      <span className="w-[5px] h-[5px] rounded-full bg-white/70" aria-hidden="true" />
+      <span
+        className='w-[5px] h-[5px] rounded-full bg-white/70'
+        aria-hidden='true'
+      />
       {label}
     </div>
-  )
+  );
 }
 
 interface ScaleBarProperties {
-  readonly actual: number
-  readonly colorToken: string
+  readonly actual: number;
+  readonly colorToken: string;
 }
 
 function ScaleBar({ actual, colorToken }: ScaleBarProperties) {
-  const markerPct = Math.min(PERCENT_SCALE, Math.max(0, (actual / MAX_INTENSITY) * PERCENT_SCALE))
+  const markerPct = Math.min(
+    PERCENT_SCALE,
+    Math.max(0, (actual / MAX_INTENSITY) * PERCENT_SCALE),
+  );
   return (
-    <div className="intensity-scale mt-[var(--space-md)]" aria-hidden="true">
+    <div className='intensity-scale mt-[var(--space-md)]' aria-hidden='true'>
       <div
-        className="intensity-scale-bar relative h-[6px] rounded-[3px] opacity-50 overflow-visible"
+        className='intensity-scale-bar relative h-[6px] rounded-[3px] opacity-50 overflow-visible'
         style={{
           background:
             'linear-gradient(to right, var(--color-intensity-low) 0%, var(--color-intensity-moderate) 50%, var(--color-intensity-high) 100%)',
         }}
-        role="presentation"
+        role='presentation'
       >
         <div
-          className="intensity-scale-marker absolute top-1/2 w-[14px] h-[14px] rounded-full border-[2.5px] border-[var(--color-surface)]"
+          className='intensity-scale-marker absolute top-1/2 w-[14px] h-[14px] rounded-full border-[2.5px] border-[var(--color-surface)]'
           style={{
             left: `${markerPct}%`,
             transform: 'translate(-50%, -50%)',
@@ -74,71 +80,90 @@ function ScaleBar({ actual, colorToken }: ScaleBarProperties) {
           }}
         />
       </div>
-      <div className="flex justify-between mt-[var(--space-xs)]">
-        <span className="text-[var(--text-xs)] text-[var(--color-text-disabled)] font-medium">Low · 0</span>
-        <span className="text-[var(--text-xs)] text-[var(--color-text-disabled)] font-medium">200</span>
-        <span className="text-[var(--text-xs)] text-[var(--color-text-disabled)] font-medium">High · 300+</span>
+      <div className='flex justify-between mt-[var(--space-xs)]'>
+        <span className='text-xs text-[var(--color-text-disabled)] font-medium'>
+          Low · 0
+        </span>
+        <span className='text-xs text-[var(--color-text-disabled)] font-medium'>
+          200
+        </span>
+        <span className='text-xs text-[var(--color-text-disabled)] font-medium'>
+          High · 300+
+        </span>
       </div>
     </div>
-  )
+  );
 }
 
 export function CarbonIntensityCard({ intensity, error, onRetry }: Properties) {
   if (error) {
     return (
-      <article data-testid="carbon-intensity-card" className="relative overflow-hidden rounded-[var(--radius-card)] p-[var(--space-lg)] shadow-[0_4px_32px_rgba(0,0,0,0.45)] bg-[var(--color-intensity-high-bg)] border border-[var(--color-intensity-high-border)] flex items-center justify-between gap-md">
-        <p role="alert" className="text-sm text-[var(--color-intensity-high)]">Carbon intensity unavailable</p>
+      <article
+        data-testid='carbon-intensity-card'
+        className='relative overflow-hidden rounded-[var(--radius-card)] p-[var(--space-lg)] shadow-[0_4px_32px_rgba(0,0,0,0.45)] bg-[var(--color-intensity-high-bg)] border border-[var(--color-intensity-high-border)] flex items-center justify-between gap-md'
+      >
+        <p role='alert' className='text-sm text-[var(--color-intensity-high)]'>
+          Carbon intensity unavailable
+        </p>
         {onRetry && (
-          <Primitive.button type="button" onClick={onRetry} aria-label="Retry loading carbon intensity" className="text-xs font-semibold text-[var(--color-intensity-high)] border border-[var(--color-intensity-high-border)] rounded-button px-3 py-1 cursor-pointer">
+          <Primitive.button
+            type='button'
+            onClick={onRetry}
+            aria-label='Retry loading carbon intensity'
+            className='text-xs font-semibold text-[var(--color-intensity-high)] border border-[var(--color-intensity-high-border)] rounded-button px-3 py-1 cursor-pointer'
+          >
             Retry
           </Primitive.button>
         )}
       </article>
-    )
+    );
   }
-  const colorToken = `var(--color-intensity-${intensity.band})`
-  const bgToken = `var(--color-intensity-${intensity.band}-bg)`
-  const borderToken = `var(--color-intensity-${intensity.band}-border)`
-  const time = timeFormatter.format(new Date(intensity.updatedAt))
+  const colorToken = `var(--color-intensity-${intensity.band})`;
+  const bgToken = `var(--color-intensity-${intensity.band}-bg)`;
+  const borderToken = `var(--color-intensity-${intensity.band}-border)`;
+  const time = timeFormatter.format(new Date(intensity.updatedAt));
 
   return (
     <article
-      data-testid="carbon-intensity-card"
-      aria-labelledby="intensity-heading"
-      className="relative overflow-hidden rounded-[var(--radius-card)] p-[var(--space-lg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_4px_32px_rgba(0,0,0,0.45)]"
+      data-testid='carbon-intensity-card'
+      aria-labelledby='intensity-heading'
+      className='relative overflow-hidden rounded-[var(--radius-card)] p-[var(--space-lg)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_4px_32px_rgba(0,0,0,0.45)]'
       style={{ background: bgToken, border: `1px solid ${borderToken}` }}
     >
-      <div className="flex items-center justify-between mb-[var(--space-md)]">
+      <div className='flex items-center justify-between mb-[var(--space-md)]'>
         <span
-          id="intensity-heading"
-          className="text-[var(--text-sm)] font-semibold text-[var(--color-text-secondary)] uppercase tracking-[0.08em]"
+          id='intensity-heading'
+          className='text-sm font-semibold text-[var(--color-text-secondary)] uppercase tracking-[0.08em]'
         >
           Carbon Intensity
         </span>
         <IntensityBadge band={intensity.band} colorToken={colorToken} />
       </div>
-      <div className="flex items-baseline gap-[var(--space-sm)] mb-[var(--space-sm)]">
+      <div className='flex items-baseline gap-[var(--space-sm)] mb-[var(--space-sm)]'>
         <span
-          className="font-display text-hero font-extrabold leading-none tabular-nums tracking-[-0.04em]"
+          className='font-display text-hero font-extrabold leading-none tabular-nums tracking-[-0.04em]'
           aria-label={`${intensity.actual} grams CO2 per kilowatt-hour`}
           style={{ color: colorToken, fontFeatureSettings: "'tnum'" }}
         >
           {intensity.actual}
         </span>
-        <span className="text-base font-normal text-[var(--color-text-secondary)] pb-[6px]" aria-hidden="true">
+        <span
+          className='text-base font-normal text-[var(--color-text-secondary)] pb-[6px]'
+          aria-hidden='true'
+        >
           gCO₂/kWh
         </span>
       </div>
       <ScaleBar actual={intensity.actual} colorToken={colorToken} />
-      <span className="sr-only">
+      <span className='sr-only'>
         Carbon intensity: {intensity.actual} gCO₂/kWh, {intensity.band} level
       </span>
       <p
-        className="intensity-timestamp mt-[var(--space-md)] text-[var(--text-xs)] text-[var(--color-text-disabled)]"
+        className='intensity-timestamp mt-[var(--space-md)] text-xs text-[var(--color-text-disabled)]'
         aria-label={`Data updated at ${time}`}
       >
         Updated {time}
       </p>
     </article>
-  )
+  );
 }

--- a/src/components/results/RegionHeader.tsx
+++ b/src/components/results/RegionHeader.tsx
@@ -1,14 +1,17 @@
 interface Properties {
-  readonly postcode: string
-  readonly regionName: string
-  readonly gspId: string
+  readonly postcode: string;
+  readonly regionName: string;
+  readonly gspId: string;
 }
 
 export function RegionHeader({ postcode, regionName, gspId }: Properties) {
-  const gspLetter = gspId.startsWith('_') ? gspId.slice(1) : gspId
+  const gspLetter = gspId.startsWith('_') ? gspId.slice(1) : gspId;
   return (
-    <p data-testid="region-header">
-      {postcode} · {regionName} · GSP Region {gspLetter}
-    </p>
-  )
+    <div className='flex justify-between text-sm font-semibold text-[var(--color-text-secondary)]'>
+      <p data-testid='region-header'>{postcode}</p>
+      <p>
+        {regionName} · GSP Region {gspLetter}
+      </p>
+    </div>
+  );
 }

--- a/src/services/carbon-intensity.test.ts
+++ b/src/services/carbon-intensity.test.ts
@@ -1,6 +1,6 @@
-import { carbonIntensity } from './carbon-intensity'
+import { carbonIntensity } from './carbon-intensity';
 
-const ACTUAL_INTENSITY = 85
+const ACTUAL_INTENSITY = 85;
 
 const FIXTURE = {
   data: [
@@ -9,7 +9,7 @@ const FIXTURE = {
       data: [
         {
           from: '2024-01-15T12:00Z',
-          intensity: { actual: ACTUAL_INTENSITY },
+          intensity: { actual: ACTUAL_INTENSITY, index: 'low' },
           generationmix: [
             { fuel: 'gas', perc: 40.5 },
             { fuel: 'wind', perc: 35.2 },
@@ -19,58 +19,84 @@ const FIXTURE = {
       ],
     },
   ],
-}
+};
 
 beforeEach(() => {
-  globalThis.fetch = jest.fn() as typeof fetch
-})
+  globalThis.fetch = jest.fn() as typeof fetch;
+});
 
 afterEach(() => {
-  jest.resetAllMocks()
-})
+  jest.resetAllMocks();
+});
 
-describe('carbonIntensity', () => {
+describe('carbonIntensity — response parsing', () => {
   it('extracts actual, regionName, generationMix, band and updatedAt', async () => {
-    ;(globalThis.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(FIXTURE),
-    })
+    });
 
-    const result = await carbonIntensity('SE1')
-
-    expect(result.actual).toBe(ACTUAL_INTENSITY)
-    expect(result.regionName).toBe('South East')
-    expect(result.band).toBe('low')
-    expect(result.updatedAt).toBe('2024-01-15T12:00Z')
+    const result = await carbonIntensity('SE1');
+    expect(result.actual).toBe(ACTUAL_INTENSITY);
+    expect(result.regionName).toBe('South East');
+    expect(result.band).toBe('low');
+    expect(result.updatedAt).toBe('2024-01-15T12:00Z');
     expect(result.generationMix).toEqual([
       { fuel: 'gas', perc: 40.5 },
       { fuel: 'wind', perc: 35.2 },
       { fuel: 'solar', perc: 24.3 },
-    ])
-  })
+    ]);
+  });
 
+  it('falls back to forecast when actual is absent', async () => {
+    const fixture = {
+      data: [
+        {
+          shortname: 'South East',
+          data: [
+            {
+              from: '2024-01-15T12:00Z',
+              intensity: { forecast: ACTUAL_INTENSITY, index: 'low' },
+              generationmix: [],
+            },
+          ],
+        },
+      ],
+    };
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fixture),
+    });
+    const result = await carbonIntensity('SE1');
+    expect(result.actual).toBe(ACTUAL_INTENSITY);
+  });
+});
+
+describe('carbonIntensity — request formatting', () => {
   it('uses only the outward code when a full postcode is passed', async () => {
-    ;(globalThis.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(FIXTURE),
-    })
+    });
 
-    await carbonIntensity('NR1 3AZ')
+    await carbonIntensity('NR1 3AZ');
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/postcode/NR1'),
-    )
+    );
     expect(globalThis.fetch).not.toHaveBeenCalledWith(
       expect.stringContaining('3AZ'),
-    )
-  })
+    );
+  });
+});
 
+describe('carbonIntensity — error handling', () => {
   it('throws on non-2xx response', async () => {
-    ;(globalThis.fetch as jest.Mock).mockResolvedValue({
+    (globalThis.fetch as jest.Mock).mockResolvedValue({
       ok: false,
       status: 404,
-    })
+    });
 
-    await expect(carbonIntensity('ZZZZZ')).rejects.toThrow('404')
-  })
-})
+    await expect(carbonIntensity('ZZZZZ')).rejects.toThrow('404');
+  });
+});

--- a/src/services/carbon-intensity.ts
+++ b/src/services/carbon-intensity.ts
@@ -13,23 +13,26 @@ interface ApiResponse {
     shortname: string;
     data: Array<{
       from: string;
-      intensity: { actual: number };
+      intensity: { actual?: number; forecast?: number; index: string };
       generationmix: Array<{ fuel: string; perc: number }>;
     }>;
   }>;
 }
 
-export async function carbonIntensity(postcode: string): Promise<CarbonIntensityResult> {
-  const outward = postcode.split(' ')[0]
+export async function carbonIntensity(
+  postcode: string,
+): Promise<CarbonIntensityResult> {
+  const outward = postcode.split(' ')[0];
   const response = await fetch(
     `https://api.carbonintensity.org.uk/regional/postcode/${outward}`,
-  )
-  if (!response.ok) throw new Error(`Carbon Intensity API error: ${response.status}`)
+  );
+  if (!response.ok)
+    throw new Error(`Carbon Intensity API error: ${response.status}`);
 
   const json: ApiResponse = await response.json();
   const region = json.data[0];
   const period = region.data[0];
-  const actual = period.intensity.actual;
+  const actual = period.intensity.actual ?? period.intensity.forecast ?? 0;
 
   return {
     actual,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap');
 @import "tailwindcss";
 @import "./tokens.css";
 


### PR DESCRIPTION
Fixes #87

## Changes
- Add Google Fonts import for Plus Jakarta Sans to `global.css`
- Replace arbitrary-var syntax (`font-[var(--font-display)] text-[var(--text-hero)]`) with Tailwind v4 utilities `font-display text-hero` on hero number
- Add `fontFeatureSettings: "'tnum'"` inline style to hero number span
- Strengthen test: `toHaveTextContent('142')` instead of false-positive `toBeInTheDocument()`

## Acceptance criteria
- [x] Plus Jakarta Sans loads in the browser (Google Fonts import added to `global.css`)
- [x] Hero number uses `font-display` + `text-hero` Tailwind v4 utilities (not arbitrary var syntax)
- [x] `font-feature-settings: 'tnum'` applied to the hero number
- [x] Hero number test asserts `toHaveTextContent('142')` not just `toBeInTheDocument()`
- [x] No TypeScript or ESLint errors; all tests pass (134/134)