### PR TITLE
fix(#86): RegionHeader two-column layout

### DIFF
--- a/src/components/results/RegionHeader.test.tsx
+++ b/src/components/results/RegionHeader.test.tsx
@@ -1,20 +1,48 @@
-import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
-import { RegionHeader } from './RegionHeader'
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { RegionHeader } from './RegionHeader';
 
 describe('RegionHeader', () => {
-  it('renders postcode, region name, and GSP letter joined by middle dots', () => {
-    render(<RegionHeader postcode="NR1 4AA" regionName="East England" gspId="_P" />)
-    expect(screen.getByText('NR1 4AA · East England · GSP Region P')).toBeInTheDocument()
-  })
+  it('renders postcode on the left in uppercase', () => {
+    render(
+      <RegionHeader postcode='NR1 4AA' regionName='East England' gspId='_P' />,
+    );
+    expect(screen.getByTestId('region-header-postcode')).toHaveTextContent(
+      'NR1 4AA',
+    );
+  });
+
+  it('renders region name and GSP letter on the right', () => {
+    render(
+      <RegionHeader postcode='NR1 4AA' regionName='East England' gspId='_P' />,
+    );
+    expect(screen.getByTestId('region-header-region')).toHaveTextContent(
+      'East England · GSP Region P',
+    );
+  });
 
   it('strips leading underscore from gspId', () => {
-    render(<RegionHeader postcode="SW1A 1AA" regionName="South East" gspId="_J" />)
-    expect(screen.getByText('SW1A 1AA · South East · GSP Region J')).toBeInTheDocument()
-  })
+    render(
+      <RegionHeader postcode='SW1A 1AA' regionName='South East' gspId='_J' />,
+    );
+    expect(screen.getByTestId('region-header-region')).toHaveTextContent(
+      'South East · GSP Region J',
+    );
+  });
 
   it('handles gspId without underscore prefix', () => {
-    render(<RegionHeader postcode="M1 1AE" regionName="North West" gspId="A" />)
-    expect(screen.getByText('M1 1AE · North West · GSP Region A')).toBeInTheDocument()
-  })
-})
+    render(<RegionHeader postcode='M1 1AE' regionName='North West' gspId='A' />);
+    expect(screen.getByTestId('region-header-region')).toHaveTextContent(
+      'North West · GSP Region A',
+    );
+  });
+
+  it('container has flex layout with space-between', () => {
+    render(
+      <RegionHeader postcode='NR1 4AA' regionName='East England' gspId='_P' />,
+    );
+    const container = screen.getByTestId('region-header');
+    expect(container).toHaveClass('flex');
+    expect(container).toHaveClass('justify-between');
+  });
+});

--- a/src/components/results/RegionHeader.tsx
+++ b/src/components/results/RegionHeader.tsx
@@ -1,14 +1,28 @@
 interface Properties {
-  readonly postcode: string
-  readonly regionName: string
-  readonly gspId: string
+  readonly postcode: string;
+  readonly regionName: string;
+  readonly gspId: string;
 }
 
 export function RegionHeader({ postcode, regionName, gspId }: Properties) {
-  const gspLetter = gspId.startsWith('_') ? gspId.slice(1) : gspId
+  const gspLetter = gspId.startsWith('_') ? gspId.slice(1) : gspId;
   return (
-    <p data-testid="region-header">
-      {postcode} · {regionName} · GSP Region {gspLetter}
-    </p>
-  )
+    <div
+      data-testid='region-header'
+      className='flex justify-between items-center py-[var(--space-sm)]'
+    >
+      <span
+        data-testid='region-header-postcode'
+        className='text-[length:var(--text-sm)] font-semibold text-[var(--color-text-secondary)] uppercase tracking-[0.1em]'
+      >
+        {postcode}
+      </span>
+      <span
+        data-testid='region-header-region'
+        className='text-[length:var(--text-sm)] font-medium text-[var(--color-text-secondary)] max-w-[180px] truncate'
+      >
+        {regionName} · GSP Region {gspLetter}
+      </span>
+    </div>
+  );
 }


### PR DESCRIPTION
Fixes #86. Split single p into flex row: postcode left (text-sm semibold uppercase tracking-[0.1em]), region+GSP right (text-sm medium max-w-[180px] truncate). 135/135 tests, 0 lint errors.